### PR TITLE
feature: add python bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1173,7 +1173,6 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ba0117f4212101ee6544044dae45abe1083d30ce7b29c4b5cbdfa2354e07383"
 dependencies = [
- "anyhow",
  "indoc",
  "inventory",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1173,6 +1173,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ba0117f4212101ee6544044dae45abe1083d30ce7b29c4b5cbdfa2354e07383"
 dependencies = [
+ "anyhow",
  "indoc",
  "inventory",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,7 @@ dependencies = [
  "measurements",
  "pyo3",
  "pyo3-async-runtimes",
+ "pyo3-introspection",
  "rand 0.9.2",
  "regex",
  "reqwest",
@@ -253,6 +254,15 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d630bccd429a5bb5a64b5e94f693bfc48c9f8566418fda4c494cc94f911f87cc"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -498,6 +508,17 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "goblin"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6a80adfd63bd7ffd94fefc3d22167880c440a724303080e5aa686fa36abaa96"
+dependencies = [
+ "log",
+ "plain",
+ "scroll",
+]
 
 [[package]]
 name = "h2"
@@ -981,6 +1002,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1096,6 +1123,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1109,6 +1142,12 @@ checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1143,6 +1182,7 @@ dependencies = [
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
+ "time",
  "unindent",
 ]
 
@@ -1176,6 +1216,19 @@ checksum = "025474d3928738efb38ac36d4744a74a400c901c7596199e20e45d98eb194105"
 dependencies = [
  "libc",
  "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-introspection"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c3470294ce4d56fa74c996e4244ec3ac04db0c621975993e62ff725844ab509"
+dependencies = [
+ "anyhow",
+ "goblin",
+ "serde",
+ "serde_json",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1452,6 +1505,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scroll"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1257cd4248b4132760d6524d6dda4e053bc648c9070b960929bf50cfb1e7add"
+dependencies = [
+ "scroll_derive",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed76efe62313ab6610570951494bdaa81568026e0318eaa55f167de70eeea67d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1675,6 +1748,24 @@ dependencies = [
  "rustix",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83bde6f1ec10e72d583d91623c939f623002284ef622b87de38cfd546cbf2031"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
 
 [[package]]
 name = "tinystr"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,6 +61,8 @@ dependencies = [
  "ipnet",
  "macaddr",
  "measurements",
+ "pyo3",
+ "pyo3-async-runtimes",
  "rand 0.9.2",
  "regex",
  "reqwest",
@@ -794,6 +796,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
+
+[[package]]
+name = "inventory"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc61209c082fbeb19919bee74b176221b27223e27b65d781eb91af24eb1fb46e"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "io-uring"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -910,6 +927,15 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mime"
@@ -1070,6 +1096,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1094,6 +1126,81 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d61789d7719defeb74ea5fe81f2fdfdbd28a803847077cecce2ff14e1472f6f1"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "pyo3"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba0117f4212101ee6544044dae45abe1083d30ce7b29c4b5cbdfa2354e07383"
+dependencies = [
+ "indoc",
+ "inventory",
+ "libc",
+ "memoffset",
+ "once_cell",
+ "portable-atomic",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
+ "unindent",
+]
+
+[[package]]
+name = "pyo3-async-runtimes"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6ee6d4cb3e8d5b925f5cdb38da183e0ff18122eb2048d4041c9e7034d026e23"
+dependencies = [
+ "futures",
+ "once_cell",
+ "pin-project-lite",
+ "pyo3",
+ "tokio",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fc6ddaf24947d12a9aa31ac65431fb1b851b8f4365426e182901eabfb87df5f"
+dependencies = [
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "025474d3928738efb38ac36d4744a74a400c901c7596199e20e45d98eb194105"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e64eb489f22fe1c95911b77c44cc41e7c19f3082fc81cce90f657cdc42ffded"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "100246c0ecf400b475341b8455a9213344569af29a3c841d29270e53102e0fcf"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "pyo3-build-config",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1551,6 +1658,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-lexicon"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
+
+[[package]]
 name = "tempfile"
 version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1729,6 +1842,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unindent"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ pyo3 = { version = "0.26.0", features = [
     "experimental-inspect",
     "multiple-pymethods",
     "time",
-    "anyhow"
 ], optional = true }
 pyo3-async-runtimes = { version = "0.26.0", optional = true, features = ["tokio-runtime"] }
 pyo3-introspection = { version = "0.26.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,8 @@ pyo3 = { version = "0.26.0", features = [
     "experimental-async",
     "experimental-inspect",
     "multiple-pymethods",
-    "time"
+    "time",
+    "anyhow"
 ], optional = true }
 pyo3-async-runtimes = { version = "0.26.0", optional = true, features = ["tokio-runtime"] }
 pyo3-introspection = { version = "0.26.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,11 +32,13 @@ pyo3 = { version = "0.26.0", features = [
     "experimental-async",
     "experimental-inspect",
     "multiple-pymethods",
+    "time"
 ], optional = true }
 pyo3-async-runtimes = { version = "0.26.0", optional = true, features = ["tokio-runtime"] }
+pyo3-introspection = { version = "0.26.0", optional = true }
 
 [features]
-python = ["dep:pyo3", "dep:pyo3-async-runtimes"]
+python = ["dep:pyo3", "dep:pyo3-async-runtimes", "dep:pyo3-introspection"]
 
 [profile.release]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,16 @@ tokio-stream = "0.1.17"
 async-stream = "0.3.6"
 sha2 = "0.10.9"
 base64 = "0.22.1"
+pyo3 = { version = "0.26.0", features = [
+    "extension-module",
+    "experimental-async",
+    "experimental-inspect",
+    "multiple-pymethods",
+], optional = true }
+pyo3-async-runtimes = { version = "0.26.0", optional = true, features = ["tokio-runtime"] }
+
+[features]
+python = ["dep:pyo3", "dep:pyo3-async-runtimes"]
 
 [profile.release]
 opt-level = 3
@@ -35,3 +45,7 @@ codegen-units = 1
 panic = "abort"
 incremental = false
 strip = true
+
+[lib]
+name = "asic_rs"
+crate-type = ["cdylib", "rlib"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["maturin>=1.4,<2.0"]
+build-backend = "maturin"
+
+#[project]
+#name = "asic_rs"
+#version = "0.1.0"
+#description = "Python bindings for asic-rs"
+#authors = [{ name = "Brett Rowan", email = "121075405+b-rowan@users.noreply.github.com" }]
+#license = "Apache 2.0"
+#readme = "README.md"
+#dependencies = [
+#    "pydantic"
+#]
+
+
+[tool.maturin]
+# maturin will build the Rust cdylib and install it inside the package
+package-name = "asic_rs"
+features = ["python"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,19 +2,21 @@
 requires = ["maturin>=1.4,<2.0"]
 build-backend = "maturin"
 
-#[project]
-#name = "asic_rs"
-#version = "0.1.0"
-#description = "Python bindings for asic-rs"
-#authors = [{ name = "Brett Rowan", email = "121075405+b-rowan@users.noreply.github.com" }]
-#license = "Apache 2.0"
-#readme = "README.md"
-#dependencies = [
-#    "pydantic"
-#]
+[project]
+name = "pyasic_rs"
+version = "0.1.0"
+description = "Python bindings for asic-rs"
+authors = [{ name = "Brett Rowan", email = "121075405+b-rowan@users.noreply.github.com" }]
+license = "Apache 2.0"
+readme = "README.md"
+dependencies = [
+    "pydantic"
+]
 
 
 [tool.maturin]
 # maturin will build the Rust cdylib and install it inside the package
-package-name = "asic_rs"
+package-name = "pyasic_rs"
+module-name = "pyasic_rs.asic_rs"
 features = ["python"]
+python-source = "python"

--- a/python/pyasic_rs/__init__.py
+++ b/python/pyasic_rs/__init__.py
@@ -1,0 +1,1 @@
+from .factory import MinerFactory

--- a/python/pyasic_rs/data.py
+++ b/python/pyasic_rs/data.py
@@ -1,0 +1,217 @@
+from datetime import timedelta
+from enum import IntEnum
+from ipaddress import IPv4Address
+from typing import Annotated, Self
+
+from pydantic import BaseModel, ConfigDict, BeforeValidator, field_serializer, model_serializer
+
+
+class MinerHardware(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    chips: int | None
+    fans: int | None
+    boards: int | None
+
+
+class DeviceInfo(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    make: Annotated[str, BeforeValidator(str)]
+    model: Annotated[str, BeforeValidator(str)]
+    hardware: MinerHardware
+    firmware: Annotated[str, BeforeValidator(str)]
+    algo: Annotated[str, BeforeValidator(str)]
+
+
+class HashRateUnit(IntEnum):
+    H = 1
+    KH = H * 1000
+    MH = KH * 1000
+    GH = MH * 1000
+    TH = GH * 1000
+    PH = TH * 1000
+    EH = PH * 1000
+    ZH = EH * 1000
+
+    default = TH
+
+    @classmethod
+    def from_asic_rs(cls, val):
+        val = int(val)
+        if val == 0:
+            return cls.H
+        if val == 1:
+            return cls.KH
+        if val == 2:
+            return cls.MH
+        if val == 3:
+            return cls.GH
+        if val == 4:
+            return cls.TH
+        if val == 5:
+            return cls.PH
+        if val == 6:
+            return cls.EH
+        if val == 7:
+            return cls.ZH
+        return cls.default
+
+    def __str__(self):
+        if self.value == self.H:
+            return "H/s"
+        if self.value == self.KH:
+            return "KH/s"
+        if self.value == self.MH:
+            return "MH/s"
+        if self.value == self.GH:
+            return "GH/s"
+        if self.value == self.TH:
+            return "TH/s"
+        if self.value == self.PH:
+            return "PH/s"
+        if self.value == self.EH:
+            return "EH/s"
+        if self.value == self.ZH:
+            return "ZH/s"
+
+    @classmethod
+    def from_str(cls, value: str):
+        if value == "H":
+            return cls.H
+        elif value == "KH":
+            return cls.KH
+        elif value == "MH":
+            return cls.MH
+        elif value == "GH":
+            return cls.GH
+        elif value == "TH":
+            return cls.TH
+        elif value == "PH":
+            return cls.PH
+        elif value == "EH":
+            return cls.EH
+        elif value == "ZH":
+            return cls.ZH
+        return cls.default
+
+    def __repr__(self):
+        return str(self)
+
+
+class HashRate(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    value: float
+    unit: Annotated[HashRateUnit, BeforeValidator(HashRateUnit.from_asic_rs)]
+    algo: str
+
+    def __float__(self):
+        return self.value
+
+    @model_serializer
+    def serialize_hashrate(self):
+        return self.into_unit(unit=HashRateUnit.default).value
+
+    def into_unit(self, unit: HashRateUnit) -> Self:
+        return HashRate(
+            value=(self.value / int(self.unit)) * int(unit),
+            unit=unit,
+            algo=self.algo
+        )
+
+
+class ChipData(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    position: int
+    hashrate: HashRate | None
+    temperature: float | None
+    voltage: float | None
+    frequency: float | None
+    tuned: bool | None
+    working: bool | None
+
+
+class BoardData(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    position: int
+    hashrate: HashRate | None
+    expected_hashrate: HashRate | None
+    board_temperature: float | None
+    intake_temperature: float | None
+    outlet_temperature: float | None
+    expected_chips: int | None
+    working_chips: int | None
+    serial_number: str | None
+    chips: list[ChipData]
+    voltage: float | None
+    frequency: float | None
+    tuned: bool | None
+    active: bool | None
+
+
+class FanData(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    position: int
+    rpm: float | None
+
+
+class PoolData(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    position: int | None
+    url: Annotated[str, BeforeValidator(str)] | None
+    accepted_shares: int | None
+    rejected_shares: int | None
+    active: bool | None
+    alive: bool | None
+    user: str | None
+
+
+class MinerMessage(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    timestamp: int
+    code: int
+    message: str
+    severity: Annotated[str, BeforeValidator(str)]
+
+
+class MinerData(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    schema_version: str
+    timestamp: int
+    ip: IPv4Address
+    mac: str
+    device_info: DeviceInfo
+    serial_number: str | None
+    hostname: str | None
+    api_version: str | None
+    firmware_version: str | None
+    expected_hashboards: int | None
+    hashboards: list[BoardData]
+    hashrate: HashRate | None
+    expected_hashrate: HashRate | None
+    expected_chips: int | None
+    total_chips: int | None
+    expected_fans: int | None
+    fans: list[FanData]
+    psu_fans: list[FanData]
+    average_temperature: float | None
+    fluid_temperature: float | None
+    wattage: int | None
+    wattage_limit: int | None
+    efficiency: float | None
+    light_flashing: bool | None
+    messages: list[MinerMessage]
+    uptime: timedelta | None
+    is_mining: bool
+    pools: list[PoolData]
+
+    @field_serializer("uptime")
+    def serialize_uptime(self, uptime: timedelta, _info) -> float:
+        return uptime.total_seconds()

--- a/python/pyasic_rs/factory.py
+++ b/python/pyasic_rs/factory.py
@@ -1,0 +1,27 @@
+from typing import Self
+
+from pyasic_rs.asic_rs import MinerFactory as _rs_MinerFactory
+from .miner import Miner
+
+
+class MinerFactory:
+    def __init__(self, *, inner: _rs_MinerFactory = _rs_MinerFactory()):
+        self.__inner = inner
+
+    @classmethod
+    def from_subnet(cls, subnet: str) -> Self:
+        return cls(inner=_rs_MinerFactory.from_subnet(subnet))
+
+    @classmethod
+    def from_octets(cls, octet_1: int | str, octet_2: int | str, octet_3: int | str, octet_4: int | str) -> Self:
+        return cls(inner=_rs_MinerFactory.from_subnet(str(octet_1), str(octet_2), str(octet_3), str(octet_4)))
+
+    async def get_miner(self, ip: str) -> Miner | None:
+        base = await self.__inner.get_miner(ip)
+        if base is not None:
+            return Miner(inner=base)
+        return None
+
+    async def scan(self) -> list[Miner]:
+        bases = await self.__inner.scan()
+        return [Miner(inner=m) for m in filter(lambda x: x is not None, bases)]

--- a/python/pyasic_rs/factory.py
+++ b/python/pyasic_rs/factory.py
@@ -14,7 +14,7 @@ class MinerFactory:
 
     @classmethod
     def from_octets(cls, octet_1: int | str, octet_2: int | str, octet_3: int | str, octet_4: int | str) -> Self:
-        return cls(inner=_rs_MinerFactory.from_subnet(str(octet_1), str(octet_2), str(octet_3), str(octet_4)))
+        return cls(inner=_rs_MinerFactory.from_octets(str(octet_1), str(octet_2), str(octet_3), str(octet_4)))
 
     async def get_miner(self, ip: str) -> Miner | None:
         base = await self.__inner.get_miner(ip)

--- a/python/pyasic_rs/miner.py
+++ b/python/pyasic_rs/miner.py
@@ -1,0 +1,91 @@
+from datetime import timedelta
+
+from pyasic_rs.asic_rs import Miner as _rs_Miner
+from .data import MinerData, BoardData, HashRate, FanData, MinerMessage, PoolData
+
+
+class Miner:
+    def __init__(self, *, inner: _rs_Miner):
+        self.__inner = inner
+
+    async def get_data(self) -> MinerData:
+        return MinerData.model_validate(await self.__inner.get_data())
+
+    async def get_mac(self) -> str | None:
+        return await self.__inner.get_mac()
+
+    async def get_serial_number(self) -> str | None:
+        return await self.__inner.get_serial_number()
+
+    async def get_hostname(self) -> str | None:
+        return await self.__inner.get_hostname()
+
+    async def get_api_version(self) -> str | None:
+        return await self.__inner.get_api_version()
+
+    async def get_firmware_version(self) -> str | None:
+        return await self.__inner.get_firmware_version()
+
+    async def get_control_board_version(self) -> str | None:
+        return await self.__inner.get_control_board_version()
+
+    async def get_hashboards(self) -> list[BoardData]:
+        return [BoardData.model_validate(b) for b in await self.__inner.get_hashboards()]
+
+    async def get_hashrate(self) -> HashRate | None:
+        inner = await self.__inner.get_hashrate()
+        if inner is not None:
+            return HashRate.model_validate(inner)
+        return None
+
+    async def get_expected_hashrate(self) -> HashRate | None:
+        inner = await self.__inner.get_expected_hashrate()
+        if inner is not None:
+            return HashRate.model_validate(inner)
+        return None
+
+    async def get_fans(self) -> list[FanData]:
+        return [FanData.model_validate(f) for f in await self.__inner.get_fans()]
+
+    async def get_psu_fans(self) -> list[FanData]:
+        return [FanData.model_validate(f) for f in await self.__inner.get_psu_fans()]
+
+    async def get_fluid_temperature(self) -> float | None:
+        return await self.__inner.get_fluid_temperature()
+
+    async def get_wattage(self) -> float | None:
+        return await self.__inner.get_wattage()
+
+    async def get_wattage_limit(self) -> float | None:
+        return await self.__inner.get_wattage_limit()
+
+    async def get_light_flashing(self) -> bool | None:
+        return await self.__inner.get_light_flashing()
+
+    async def get_messages(self) -> list[MinerMessage]:
+        return [MinerMessage.model_validate(m) for m in await self.__inner.get_messages()]
+
+    async def get_uptime(self) -> timedelta | None:
+        return await self.__inner.get_uptime()
+
+    async def get_is_mining(self) -> bool | None:
+        return await self.__inner.get_is_mining()
+
+    async def get_pools(self) -> list[PoolData]:
+        return [PoolData.model_validate(b) for b in await self.__inner.get_pools()]
+
+    async def set_fault_light(self, fault: bool) -> bool | None:
+        return await self.__inner.set_fault_light(fault)
+
+    async def restart(self) -> bool | None:
+        return await self.__inner.restart()
+
+    async def pause(self, at_time: timedelta | int) -> bool | None:
+        if isinstance(at_time, int):
+            at_time = timedelta(seconds=at_time)
+        return await self.__inner.pause(at_time)
+
+    async def resume(self, at_time: timedelta | int) -> bool | None:
+        if isinstance(at_time, int):
+            at_time = timedelta(seconds=at_time)
+        return await self.__inner.restart(at_time)

--- a/python/pyasic_rs/miner.py
+++ b/python/pyasic_rs/miner.py
@@ -1,12 +1,47 @@
 from datetime import timedelta
 
 from pyasic_rs.asic_rs import Miner as _rs_Miner
+from pyasic_rs.asic_rs import MinerModel as _rs_MinerModel
+from pyasic_rs.asic_rs import HashAlgorithm as _rs_HashAlgorithm
+from pyasic_rs.asic_rs import MinerFirmware as _rs_MinerFirmware
+from pyasic_rs.asic_rs import MinerMake as _rs_MinerMake
 from .data import MinerData, BoardData, HashRate, FanData, MinerMessage, PoolData
 
 
 class Miner:
     def __init__(self, *, inner: _rs_Miner):
         self.__inner = inner
+
+    def __repr__(self):
+        return self.__inner.__repr__()
+
+    @property
+    def model(self) -> _rs_MinerModel:
+        return self.__inner.model
+
+    @property
+    def make(self) -> _rs_MinerMake:
+        return self.__inner.make
+
+    @property
+    def firmware(self) -> _rs_MinerMake:
+        return self.__inner.firmware
+
+    @property
+    def algo(self) -> _rs_HashAlgorithm:
+        return self.__inner.algo
+
+    @property
+    def expected_hashboards(self) -> int:
+        return self.__inner.expected_hashboards
+
+    @property
+    def expected_chips(self) -> int:
+        return self.__inner.expected_chips
+
+    @property
+    def expected_fans(self) -> int:
+        return self.__inner.expected_fans
 
     async def get_data(self) -> MinerData:
         return MinerData.model_validate(await self.__inner.get_data())

--- a/src/data/device/mod.rs
+++ b/src/data/device/mod.rs
@@ -1,8 +1,13 @@
+#[cfg(feature = "python")]
+use pyo3::prelude::*;
+
 use serde::{Deserialize, Serialize};
 use strum::Display;
 
 pub mod models;
 pub use models::MinerModel;
+
+#[cfg_attr(feature = "python", pyclass(str, module = "asic_rs"))]
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, Serialize, Deserialize, Display)]
 pub enum MinerFirmware {
     #[serde(rename = "Stock")]
@@ -23,6 +28,7 @@ pub enum MinerFirmware {
     MSKMiner,
 }
 
+#[cfg_attr(feature = "python", pyclass(str, module = "asic_rs"))]
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, Serialize, Deserialize, Display)]
 pub enum MinerMake {
     #[serde(rename = "AntMiner")]
@@ -39,6 +45,7 @@ pub enum MinerMake {
     BitAxe,
 }
 
+#[cfg_attr(feature = "python", pyclass(str, module = "asic_rs"))]
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, Serialize, Deserialize, Display)]
 pub enum HashAlgorithm {
     #[serde(rename = "SHA256")]
@@ -53,6 +60,7 @@ pub enum HashAlgorithm {
     Kadena,
 }
 
+#[cfg_attr(feature = "python", pyclass(get_all, module = "asic_rs"))]
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, Serialize, Deserialize)]
 pub struct DeviceInfo {
     pub make: MinerMake,
@@ -79,6 +87,7 @@ impl DeviceInfo {
     }
 }
 
+#[cfg_attr(feature = "python", pyclass(get_all, module = "asic_rs"))]
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, Serialize, Deserialize)]
 pub struct MinerHardware {
     pub chips: Option<u16>,

--- a/src/data/device/models/antminer.rs
+++ b/src/data/device/models/antminer.rs
@@ -1,6 +1,10 @@
+#[cfg(feature = "python")]
+use pyo3::prelude::*;
+
 use serde::{Deserialize, Serialize};
 use strum::Display;
 
+#[cfg_attr(feature = "python", pyclass(str, module = "asic_rs"))]
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, Serialize, Deserialize, Display)]
 pub enum AntMinerModel {
     #[serde(alias = "ANTMINER D3")]

--- a/src/data/device/models/avalon.rs
+++ b/src/data/device/models/avalon.rs
@@ -1,6 +1,10 @@
+#[cfg(feature = "python")]
+use pyo3::prelude::*;
+
 use serde::{Deserialize, Serialize};
 use strum::Display;
 
+#[cfg_attr(feature = "python", pyclass(str, module = "asic_rs"))]
 #[derive(Debug, Display, Clone, PartialEq, Eq, Serialize, Deserialize, Copy, Hash)]
 pub enum AvalonMinerModel {
     #[serde(alias = "721")]

--- a/src/data/device/models/bitaxe.rs
+++ b/src/data/device/models/bitaxe.rs
@@ -1,6 +1,10 @@
+#[cfg(feature = "python")]
+use pyo3::prelude::*;
+
 use serde::{Deserialize, Serialize};
 use strum::Display;
 
+#[cfg_attr(feature = "python", pyclass(str, module = "asic_rs"))]
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, Serialize, Deserialize, Display)]
 pub enum BitAxeModel {
     #[serde(alias = "BM1368")]

--- a/src/data/device/models/braiins.rs
+++ b/src/data/device/models/braiins.rs
@@ -1,6 +1,10 @@
+#[cfg(feature = "python")]
+use pyo3::prelude::*;
+
 use serde::{Deserialize, Serialize};
 use strum::Display;
 
+#[cfg_attr(feature = "python", pyclass(str, module = "asic_rs"))]
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, Serialize, Deserialize, Display)]
 pub enum BraiinsModel {
     #[serde(alias = "BRAIINS MINI MINER BMM 100")]

--- a/src/data/device/models/epic.rs
+++ b/src/data/device/models/epic.rs
@@ -1,6 +1,10 @@
+#[cfg(feature = "python")]
+use pyo3::prelude::*;
+
 use serde::{Deserialize, Serialize};
 use strum::Display;
 
+#[cfg_attr(feature = "python", pyclass(str, module = "asic_rs"))]
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, Serialize, Deserialize, Display)]
 pub enum EPicModel {
     #[serde(alias = "BLOCKMINER 520i")]

--- a/src/data/device/models/mod.rs
+++ b/src/data/device/models/mod.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "python")]
+use pyo3::prelude::*;
+
 use super::{MinerFirmware, MinerMake};
 use antminer::AntMinerModel;
 use avalon::AvalonMinerModel;
@@ -78,6 +81,7 @@ impl FromStr for EPicModel {
     }
 }
 
+#[cfg_attr(feature = "python", pyclass(str, module = "asic_rs"))]
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum MinerModel {

--- a/src/data/device/models/whatsminer.rs
+++ b/src/data/device/models/whatsminer.rs
@@ -1,6 +1,10 @@
+#[cfg(feature = "python")]
+use pyo3::prelude::*;
+
 use serde::{Deserialize, Serialize};
 use strum::Display;
 
+#[cfg_attr(feature = "python", pyclass(str, module = "asic_rs"))]
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, Serialize, Deserialize, Display)]
 pub enum WhatsMinerModel {
     #[serde(alias = "M20PV10")]

--- a/src/data/hashrate.rs
+++ b/src/data/hashrate.rs
@@ -22,6 +22,12 @@ pub enum HashRateUnit {
     YottaHash,
 }
 
+impl Default for HashRateUnit {
+    fn default() -> Self {
+        Self::TeraHash
+    }
+}
+
 impl HashRateUnit {
     fn to_multiplier(&self) -> f64 {
         match self {

--- a/src/data/hashrate.rs
+++ b/src/data/hashrate.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "python")]
+use pyo3::prelude::*;
+
 use measurements::Power;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -5,6 +8,7 @@ use std::{
     ops::Div,
 };
 
+#[cfg_attr(feature = "python", pyclass(str, module = "asic_rs"))]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum HashRateUnit {
     Hash,
@@ -50,6 +54,7 @@ impl Display for HashRateUnit {
     }
 }
 
+#[cfg_attr(feature = "python", pyclass(get_all, module = "asic_rs"))]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct HashRate {
     /// The current amount of hashes being computed

--- a/src/data/message.rs
+++ b/src/data/message.rs
@@ -1,12 +1,18 @@
-use serde::{Deserialize, Serialize};
+#[cfg(feature = "python")]
+use pyo3::prelude::*;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+use serde::{Deserialize, Serialize};
+use strum::Display;
+
+#[cfg_attr(feature = "python", pyclass(str, module = "asic_rs"))]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Display)]
 pub enum MessageSeverity {
     Error,
     Warning,
     Info,
 }
 
+#[cfg_attr(feature = "python", pyclass(get_all, module = "asic_rs"))]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MinerMessage {
     /// The time this message was generated or occurred

--- a/src/data/pool.rs
+++ b/src/data/pool.rs
@@ -1,6 +1,11 @@
+#[cfg(feature = "python")]
+use pyo3::prelude::*;
+use std::fmt::{Display, Formatter};
+
 use serde::{Deserialize, Serialize};
 use url::Url;
 
+#[cfg_attr(feature = "python", pyclass(str, module = "asic_rs"))]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum PoolScheme {
     StratumV1,
@@ -19,6 +24,17 @@ impl From<String> for PoolScheme {
     }
 }
 
+impl Display for PoolScheme {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PoolScheme::StratumV1 => write!(f, "stratum+tcp"),
+            PoolScheme::StratumV1SSL => write!(f, "stratum+ssl"),
+            PoolScheme::StratumV2 => write!(f, "stratum2+tcp"),
+        }
+    }
+}
+
+#[cfg_attr(feature = "python", pyclass(get_all, module = "asic_rs"))]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PoolURL {
     /// The scheme being used to connect to this pool
@@ -57,6 +73,7 @@ impl From<String> for PoolURL {
     }
 }
 
+#[cfg_attr(feature = "python", pyclass(get_all, module = "asic_rs"))]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PoolData {
     pub position: Option<u16>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,3 +4,6 @@ pub use crate::miners::listener::MinerListener;
 pub mod data;
 pub mod miners;
 pub(crate) mod test;
+
+#[cfg(feature = "python")]
+mod python;

--- a/src/miners/backends/traits.rs
+++ b/src/miners/backends/traits.rs
@@ -394,6 +394,7 @@ pub trait GetHashrate: CollectData {
         let mut collector = self.get_collector();
         let data = collector.collect(&[DataField::Hashrate]).await;
         self.parse_hashrate(&data)
+            .map(|hr| hr.as_unit(HashRateUnit::default()))
     }
     #[allow(unused_variables)]
     fn parse_hashrate(&self, data: &HashMap<DataField, Value>) -> Option<HashRate> {
@@ -408,6 +409,7 @@ pub trait GetExpectedHashrate: CollectData {
         let mut collector = self.get_collector();
         let data = collector.collect(&[DataField::ExpectedHashrate]).await;
         self.parse_expected_hashrate(&data)
+            .map(|hr| hr.as_unit(HashRateUnit::default()))
     }
     #[allow(unused_variables)]
     fn parse_expected_hashrate(&self, data: &HashMap<DataField, Value>) -> Option<HashRate> {

--- a/src/miners/factory/mod.rs
+++ b/src/miners/factory/mod.rs
@@ -436,6 +436,12 @@ impl MinerFactory {
         self.shuffle_ips();
         Ok(self)
     }
+    pub fn set_subnet(&mut self, subnet: &str) -> Result<&Self> {
+        let ips = self.hosts_from_subnet(subnet)?;
+        self.ips = ips;
+        self.shuffle_ips();
+        Ok(self)
+    }
     fn hosts_from_subnet(&self, subnet: &str) -> Result<Vec<IpAddr>> {
         let network = IpNet::from_str(subnet)?;
         Ok(network.hosts().collect())
@@ -456,6 +462,19 @@ impl MinerFactory {
         octet3: &str,
         octet4: &str,
     ) -> Result<Self> {
+        let ips = self.hosts_from_octets(octet1, octet2, octet3, octet4)?;
+        self.ips = ips;
+        self.shuffle_ips();
+        self.update_adaptive_concurrency();
+        Ok(self)
+    }
+    pub fn set_octets(
+        &mut self,
+        octet1: &str,
+        octet2: &str,
+        octet3: &str,
+        octet4: &str,
+    ) -> Result<&Self> {
         let ips = self.hosts_from_octets(octet1, octet2, octet3, octet4)?;
         self.ips = ips;
         self.shuffle_ips();

--- a/src/python/data.rs
+++ b/src/python/data.rs
@@ -2,6 +2,7 @@ use pyo3::prelude::*;
 
 use crate::data::board::BoardData as BoardData_Base;
 use crate::data::board::ChipData as ChipData_Base;
+pub(crate) use crate::data::device::{HashAlgorithm, MinerFirmware, MinerMake, MinerModel};
 use crate::data::fan::FanData as FanData_Base;
 use crate::data::miner::MinerData as MinerData_Base;
 use crate::data::{device::DeviceInfo, hashrate::HashRate, message::MinerMessage, pool::PoolData};
@@ -164,5 +165,33 @@ impl From<&MinerData_Base> for MinerData {
 impl MinerData {
     pub fn __repr__<'a>(&self) -> String {
         serde_json::to_string(self).unwrap()
+    }
+}
+
+#[pymethods]
+impl MinerModel {
+    pub fn __repr__<'a>(&self) -> String {
+        self.to_string()
+    }
+}
+
+#[pymethods]
+impl MinerMake {
+    pub fn __repr__<'a>(&self) -> String {
+        self.to_string()
+    }
+}
+
+#[pymethods]
+impl MinerFirmware {
+    pub fn __repr__<'a>(&self) -> String {
+        self.to_string()
+    }
+}
+
+#[pymethods]
+impl HashAlgorithm {
+    pub fn __repr__<'a>(&self) -> String {
+        self.to_string()
     }
 }

--- a/src/python/data.rs
+++ b/src/python/data.rs
@@ -1,0 +1,168 @@
+use pyo3::prelude::*;
+
+use crate::data::board::BoardData as BoardData_Base;
+use crate::data::board::ChipData as ChipData_Base;
+use crate::data::fan::FanData as FanData_Base;
+use crate::data::miner::MinerData as MinerData_Base;
+use crate::data::{device::DeviceInfo, hashrate::HashRate, message::MinerMessage, pool::PoolData};
+use serde::{Deserialize, Serialize};
+use std::{net::IpAddr, time::Duration};
+
+#[pyclass(get_all, module = "asic_rs")]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct ChipData {
+    pub position: u16,
+    pub hashrate: Option<HashRate>,
+    pub temperature: Option<f64>,
+    pub voltage: Option<f64>,
+    pub frequency: Option<f64>,
+    pub tuned: Option<bool>,
+    pub working: Option<bool>,
+}
+
+impl From<&ChipData_Base> for ChipData {
+    fn from(base: &ChipData_Base) -> Self {
+        Self {
+            position: base.position,
+            hashrate: base.hashrate.clone(),
+            temperature: base.temperature.map(|t| t.as_celsius()),
+            voltage: base.voltage.map(|v| v.as_volts()),
+            frequency: base.frequency.map(|f| f.as_megahertz()),
+            tuned: base.tuned,
+            working: base.working,
+        }
+    }
+}
+
+#[pyclass(get_all, module = "asic_rs")]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct BoardData {
+    pub position: u8,
+    pub hashrate: Option<HashRate>,
+    pub expected_hashrate: Option<HashRate>,
+    pub board_temperature: Option<f64>,
+    pub intake_temperature: Option<f64>,
+    pub outlet_temperature: Option<f64>,
+    pub expected_chips: Option<u16>,
+    pub working_chips: Option<u16>,
+    pub serial_number: Option<String>,
+    pub chips: Vec<ChipData>,
+    pub voltage: Option<f64>,
+    pub frequency: Option<f64>,
+    pub tuned: Option<bool>,
+    pub active: Option<bool>,
+}
+
+impl From<&BoardData_Base> for BoardData {
+    fn from(base: &BoardData_Base) -> Self {
+        Self {
+            position: base.position,
+            hashrate: base.hashrate.clone(),
+            expected_hashrate: base.expected_hashrate.clone(),
+            board_temperature: base.board_temperature.map(|t| t.as_celsius()),
+            intake_temperature: base.intake_temperature.map(|t| t.as_celsius()),
+            outlet_temperature: base.outlet_temperature.map(|t| t.as_celsius()),
+            expected_chips: base.expected_chips,
+            working_chips: base.working_chips,
+            serial_number: base.serial_number.clone(),
+            chips: base.chips.iter().map(ChipData::from).collect(),
+            voltage: base.voltage.map(|v| v.as_volts()),
+            frequency: base.frequency.map(|f| f.as_megahertz()),
+            tuned: base.tuned,
+            active: base.active,
+        }
+    }
+}
+
+#[pyclass(get_all, module = "asic_rs")]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct FanData {
+    pub position: i16,
+    pub rpm: Option<f64>,
+}
+
+impl From<&FanData_Base> for FanData {
+    fn from(base: &FanData_Base) -> Self {
+        Self {
+            position: base.position,
+            rpm: base.rpm.map(|r| r.as_rpm()),
+        }
+    }
+}
+
+#[pyclass(get_all, module = "asic_rs")]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MinerData {
+    pub schema_version: String,
+    pub timestamp: u64,
+    pub ip: IpAddr,
+    pub mac: Option<String>,
+    pub device_info: DeviceInfo,
+    pub serial_number: Option<String>,
+    pub hostname: Option<String>,
+    pub api_version: Option<String>,
+    pub firmware_version: Option<String>,
+    pub control_board_version: Option<String>,
+    pub expected_hashboards: Option<u8>,
+    pub hashboards: Vec<BoardData>,
+    pub hashrate: Option<HashRate>,
+    pub expected_hashrate: Option<HashRate>,
+    pub expected_chips: Option<u16>,
+    pub total_chips: Option<u16>,
+    pub expected_fans: Option<u8>,
+    pub fans: Vec<FanData>,
+    pub psu_fans: Vec<FanData>,
+    pub average_temperature: Option<f64>,
+    pub fluid_temperature: Option<f64>,
+    pub wattage: Option<f64>,
+    pub wattage_limit: Option<f64>,
+    pub efficiency: Option<f64>,
+    pub light_flashing: Option<bool>,
+    pub messages: Vec<MinerMessage>,
+    pub uptime: Option<Duration>,
+    pub is_mining: bool,
+    pub pools: Vec<PoolData>,
+}
+
+impl From<&MinerData_Base> for MinerData {
+    fn from(base: &MinerData_Base) -> Self {
+        Self {
+            schema_version: base.schema_version.clone(),
+            timestamp: base.timestamp,
+            ip: base.ip,
+            mac: base.mac.map(|m| m.to_string()),
+            device_info: base.device_info,
+            serial_number: base.serial_number.clone(),
+            hostname: base.hostname.clone(),
+            api_version: base.api_version.clone(),
+            firmware_version: base.firmware_version.clone(),
+            control_board_version: base.control_board_version.clone(),
+            expected_hashboards: base.expected_hashboards,
+            hashboards: base.hashboards.iter().map(BoardData::from).collect(),
+            hashrate: base.hashrate.clone(),
+            expected_hashrate: base.expected_hashrate.clone(),
+            expected_chips: base.expected_chips,
+            total_chips: base.total_chips,
+            expected_fans: base.expected_fans,
+            fans: base.fans.iter().map(FanData::from).collect(),
+            psu_fans: base.psu_fans.iter().map(FanData::from).collect(),
+            average_temperature: base.average_temperature.map(|t| t.as_celsius()),
+            fluid_temperature: base.fluid_temperature.map(|t| t.as_celsius()),
+            wattage: base.wattage.map(|w| w.as_watts()),
+            wattage_limit: base.wattage_limit.map(|w| w.as_watts()),
+            efficiency: base.efficiency,
+            light_flashing: base.light_flashing,
+            messages: base.messages.clone(),
+            uptime: base.uptime,
+            is_mining: base.is_mining,
+            pools: base.pools.clone(),
+        }
+    }
+}
+
+#[pymethods]
+impl MinerData {
+    pub fn __repr__<'a>(&self) -> String {
+        serde_json::to_string(self).unwrap()
+    }
+}

--- a/src/python/factory.rs
+++ b/src/python/factory.rs
@@ -1,7 +1,7 @@
 use crate::miners::factory::MinerFactory as MinerFactory_Base;
 use crate::python::miner::Miner;
 
-use pyo3::exceptions::{PyConnectionError, PyValueError};
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::PyType;
 use std::net::IpAddr;
@@ -41,7 +41,7 @@ impl MinerFactory {
         let factory = MinerFactory_Base::new().with_octets(&octet1, &octet2, &octet3, &octet4);
         match factory {
             Ok(f) => Ok(Self { inner: Arc::new(f) }),
-            Err(e) => Err(PyValueError::new_err(e.to_string())),
+            Err(e) => Err(PyErr::from(e)),
         }
     }
 
@@ -51,7 +51,7 @@ impl MinerFactory {
             let miners = inner.scan().await;
             match miners {
                 Ok(miners) => Ok(miners.into_iter().map(Miner::from).collect::<Vec<Miner>>()),
-                Err(e) => Err(PyValueError::new_err(e.to_string())),
+                Err(e) => Err(PyErr::from(e)),
             }
         })
     }
@@ -63,7 +63,7 @@ impl MinerFactory {
             match miner {
                 Ok(Some(miner)) => Ok(Some(Miner::from(miner))),
                 Ok(None) => Ok(None),
-                Err(e) => Err(PyConnectionError::new_err(e.to_string())),
+                Err(e) => Err(PyErr::from(e)),
             }
         })
     }

--- a/src/python/factory.rs
+++ b/src/python/factory.rs
@@ -23,8 +23,22 @@ impl MinerFactory {
     }
 
     #[classmethod]
-    pub fn with_subnet(_cls: &Bound<'_, PyType>, subnet: String) -> PyResult<Self> {
+    pub fn from_subnet(_cls: &Bound<'_, PyType>, subnet: String) -> PyResult<Self> {
         let factory = MinerFactory_Base::new().with_subnet(&subnet);
+        match factory {
+            Ok(f) => Ok(Self { inner: Arc::new(f) }),
+            Err(e) => Err(PyValueError::new_err(e.to_string())),
+        }
+    }
+    #[classmethod]
+    pub fn from_octets(
+        _cls: &Bound<'_, PyType>,
+        octet1: String,
+        octet2: String,
+        octet3: String,
+        octet4: String,
+    ) -> PyResult<Self> {
+        let factory = MinerFactory_Base::new().with_octets(&octet1, &octet2, &octet3, &octet4);
         match factory {
             Ok(f) => Ok(Self { inner: Arc::new(f) }),
             Err(e) => Err(PyValueError::new_err(e.to_string())),

--- a/src/python/factory.rs
+++ b/src/python/factory.rs
@@ -1,0 +1,56 @@
+use crate::miners::factory::MinerFactory as MinerFactory_Base;
+use crate::python::miner::Miner;
+
+use pyo3::exceptions::{PyConnectionError, PyValueError};
+use pyo3::prelude::*;
+use pyo3::types::PyType;
+use std::net::IpAddr;
+use std::str::FromStr;
+use std::sync::Arc;
+
+#[pyclass(module = "asic_rs")]
+pub(crate) struct MinerFactory {
+    inner: Arc<MinerFactory_Base>,
+}
+
+#[pymethods]
+impl MinerFactory {
+    #[new]
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(MinerFactory_Base::new()),
+        }
+    }
+
+    #[classmethod]
+    pub fn with_subnet(_cls: &Bound<'_, PyType>, subnet: String) -> PyResult<Self> {
+        let factory = MinerFactory_Base::new().with_subnet(&subnet);
+        match factory {
+            Ok(f) => Ok(Self { inner: Arc::new(f) }),
+            Err(e) => Err(PyValueError::new_err(e.to_string())),
+        }
+    }
+
+    pub fn scan<'a>(&self, py: Python<'a>) -> PyResult<Bound<'a, PyAny>> {
+        let inner = Arc::clone(&self.inner);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let miners = inner.scan().await;
+            match miners {
+                Ok(miners) => Ok(miners.into_iter().map(Miner::from).collect::<Vec<Miner>>()),
+                Err(e) => Err(PyValueError::new_err(e.to_string())),
+            }
+        })
+    }
+
+    pub fn get_miner<'a>(&self, py: Python<'a>, ip: String) -> PyResult<Bound<'a, PyAny>> {
+        let inner = Arc::clone(&self.inner);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let miner = inner.get_miner(IpAddr::from_str(&ip)?).await;
+            match miner {
+                Ok(Some(miner)) => Ok(Some(Miner::from(miner))),
+                Ok(None) => Ok(None),
+                Err(e) => Err(PyConnectionError::new_err(e.to_string())),
+            }
+        })
+    }
+}

--- a/src/python/factory.rs
+++ b/src/python/factory.rs
@@ -1,7 +1,7 @@
 use crate::miners::factory::MinerFactory as MinerFactory_Base;
 use crate::python::miner::Miner;
 
-use pyo3::exceptions::PyValueError;
+use pyo3::exceptions::{PyConnectionError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::PyType;
 use std::net::IpAddr;
@@ -41,7 +41,7 @@ impl MinerFactory {
         let factory = MinerFactory_Base::new().with_octets(&octet1, &octet2, &octet3, &octet4);
         match factory {
             Ok(f) => Ok(Self { inner: Arc::new(f) }),
-            Err(e) => Err(PyErr::from(e)),
+            Err(e) => Err(PyValueError::new_err(e.to_string())),
         }
     }
 
@@ -51,7 +51,7 @@ impl MinerFactory {
             let miners = inner.scan().await;
             match miners {
                 Ok(miners) => Ok(miners.into_iter().map(Miner::from).collect::<Vec<Miner>>()),
-                Err(e) => Err(PyErr::from(e)),
+                Err(e) => Err(PyValueError::new_err(e.to_string())),
             }
         })
     }
@@ -63,7 +63,7 @@ impl MinerFactory {
             match miner {
                 Ok(Some(miner)) => Ok(Some(Miner::from(miner))),
                 Ok(None) => Ok(None),
-                Err(e) => Err(PyErr::from(e)),
+                Err(e) => Err(PyConnectionError::new_err(e.to_string())),
             }
         })
     }

--- a/src/python/miner.rs
+++ b/src/python/miner.rs
@@ -1,6 +1,7 @@
 use super::data::{BoardData, FanData, MinerData};
 use crate::data::device::{HashAlgorithm, MinerFirmware, MinerHardware, MinerMake, MinerModel};
 use crate::miners::backends::traits::Miner as MinerTrait;
+use std::net::IpAddr;
 
 use pyo3::prelude::*;
 use std::sync::Arc;
@@ -28,7 +29,18 @@ impl From<Box<dyn MinerTrait>> for Miner {
 #[pymethods]
 impl Miner {
     fn __repr__(&self) -> String {
-        format!("{} {} ({})", self.make(), self.model(), self.firmware())
+        format!(
+            "{} {} ({}): {}",
+            self.make(),
+            self.model(),
+            self.firmware(),
+            self.ip(),
+        )
+    }
+
+    #[getter]
+    fn ip(&self) -> IpAddr {
+        self.inner.get_ip()
     }
 
     #[getter]

--- a/src/python/miner.rs
+++ b/src/python/miner.rs
@@ -1,9 +1,10 @@
-use super::data::MinerData;
+use super::data::{BoardData, FanData, MinerData};
 use crate::data::device::{MinerFirmware, MinerHardware, MinerMake, MinerModel};
 use crate::miners::backends::traits::Miner as MinerTrait;
 
 use pyo3::prelude::*;
 use std::sync::Arc;
+use std::time::Duration;
 
 #[pyclass(module = "asic_rs")]
 pub(crate) struct Miner {
@@ -47,11 +48,198 @@ impl Miner {
         self.inner.get_device_info().hardware
     }
 
+    #[getter]
+    fn expected_hashboards(&self) -> Option<u8> {
+        self.inner.get_expected_hashboards()
+    }
+
+    #[getter]
+    fn expected_chips(&self) -> Option<u16> {
+        self.inner.get_expected_chips()
+    }
+
+    #[getter]
+    fn expected_fans(&self) -> Option<u8> {
+        self.inner.get_expected_fans()
+    }
+
+    // Data functions
     pub fn get_data<'a>(&self, py: Python<'a>) -> PyResult<Bound<'a, PyAny>> {
         let inner = Arc::clone(&self.inner);
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let data = inner.get_data().await;
             Ok(MinerData::from(&data))
+        })
+    }
+    pub fn get_mac<'a>(&self, py: Python<'a>) -> PyResult<Bound<'a, PyAny>> {
+        let inner = Arc::clone(&self.inner);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let data = inner.get_mac().await;
+            Ok(data.map(|m| m.to_string()))
+        })
+    }
+    pub fn get_serial_number<'a>(&self, py: Python<'a>) -> PyResult<Bound<'a, PyAny>> {
+        let inner = Arc::clone(&self.inner);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let data = inner.get_serial_number().await;
+            Ok(data)
+        })
+    }
+    pub fn get_hostname<'a>(&self, py: Python<'a>) -> PyResult<Bound<'a, PyAny>> {
+        let inner = Arc::clone(&self.inner);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let data = inner.get_hostname().await;
+            Ok(data)
+        })
+    }
+    pub fn get_api_version<'a>(&self, py: Python<'a>) -> PyResult<Bound<'a, PyAny>> {
+        let inner = Arc::clone(&self.inner);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let data = inner.get_api_version().await;
+            Ok(data)
+        })
+    }
+    pub fn get_firmware_version<'a>(&self, py: Python<'a>) -> PyResult<Bound<'a, PyAny>> {
+        let inner = Arc::clone(&self.inner);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let data = inner.get_firmware_version().await;
+            Ok(data)
+        })
+    }
+    pub fn get_control_board_version<'a>(&self, py: Python<'a>) -> PyResult<Bound<'a, PyAny>> {
+        let inner = Arc::clone(&self.inner);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let data = inner.get_control_board_version().await;
+            Ok(data)
+        })
+    }
+    pub fn get_hashboards<'a>(&self, py: Python<'a>) -> PyResult<Bound<'a, PyAny>> {
+        let inner = Arc::clone(&self.inner);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let data = inner.get_hashboards().await;
+            Ok(data.iter().map(BoardData::from).collect::<Vec<BoardData>>())
+        })
+    }
+    pub fn get_hashrate<'a>(&self, py: Python<'a>) -> PyResult<Bound<'a, PyAny>> {
+        let inner = Arc::clone(&self.inner);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let data = inner.get_hashrate().await;
+            Ok(data)
+        })
+    }
+    pub fn get_expected_hashrate<'a>(&self, py: Python<'a>) -> PyResult<Bound<'a, PyAny>> {
+        let inner = Arc::clone(&self.inner);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let data = inner.get_expected_hashrate().await;
+            Ok(data)
+        })
+    }
+    pub fn get_fans<'a>(&self, py: Python<'a>) -> PyResult<Bound<'a, PyAny>> {
+        let inner = Arc::clone(&self.inner);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let data = inner.get_fans().await;
+            Ok(data.iter().map(FanData::from).collect::<Vec<FanData>>())
+        })
+    }
+    pub fn get_psu_fans<'a>(&self, py: Python<'a>) -> PyResult<Bound<'a, PyAny>> {
+        let inner = Arc::clone(&self.inner);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let data = inner.get_psu_fans().await;
+            Ok(data.iter().map(FanData::from).collect::<Vec<FanData>>())
+        })
+    }
+    pub fn get_fluid_temperature<'a>(&self, py: Python<'a>) -> PyResult<Bound<'a, PyAny>> {
+        let inner = Arc::clone(&self.inner);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let data = inner.get_fluid_temperature().await;
+            Ok(data.map(|t| t.as_celsius()))
+        })
+    }
+    pub fn get_wattage<'a>(&self, py: Python<'a>) -> PyResult<Bound<'a, PyAny>> {
+        let inner = Arc::clone(&self.inner);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let data = inner.get_wattage().await;
+            Ok(data.map(|w| w.as_watts()))
+        })
+    }
+    pub fn get_wattage_limit<'a>(&self, py: Python<'a>) -> PyResult<Bound<'a, PyAny>> {
+        let inner = Arc::clone(&self.inner);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let data = inner.get_wattage_limit().await;
+            Ok(data.map(|w| w.as_watts()))
+        })
+    }
+    pub fn get_light_flashing<'a>(&self, py: Python<'a>) -> PyResult<Bound<'a, PyAny>> {
+        let inner = Arc::clone(&self.inner);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let data = inner.get_light_flashing().await;
+            Ok(data)
+        })
+    }
+    pub fn get_messages<'a>(&self, py: Python<'a>) -> PyResult<Bound<'a, PyAny>> {
+        let inner = Arc::clone(&self.inner);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let data = inner.get_messages().await;
+            Ok(data)
+        })
+    }
+    pub fn get_uptime<'a>(&self, py: Python<'a>) -> PyResult<Bound<'a, PyAny>> {
+        let inner = Arc::clone(&self.inner);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let data = inner.get_uptime().await;
+            Ok(data)
+        })
+    }
+    pub fn get_is_mining<'a>(&self, py: Python<'a>) -> PyResult<Bound<'a, PyAny>> {
+        let inner = Arc::clone(&self.inner);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let data = inner.get_is_mining().await;
+            Ok(data)
+        })
+    }
+    pub fn get_pools<'a>(&self, py: Python<'a>) -> PyResult<Bound<'a, PyAny>> {
+        let inner = Arc::clone(&self.inner);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let data = inner.get_pools().await;
+            Ok(data)
+        })
+    }
+
+    // Control functions
+    pub fn set_fault_light<'a>(&self, py: Python<'a>, fault: bool) -> PyResult<Bound<'a, PyAny>> {
+        let inner = Arc::clone(&self.inner);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let data = inner.set_fault_light(fault).await;
+            Ok(data.ok())
+        })
+    }
+    pub fn restart<'a>(&self, py: Python<'a>) -> PyResult<Bound<'a, PyAny>> {
+        let inner = Arc::clone(&self.inner);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let data = inner.restart().await;
+            Ok(data.ok())
+        })
+    }
+    pub fn pause<'a>(
+        &self,
+        py: Python<'a>,
+        at_time: Option<Duration>,
+    ) -> PyResult<Bound<'a, PyAny>> {
+        let inner = Arc::clone(&self.inner);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let data = inner.pause(at_time).await;
+            Ok(data.ok())
+        })
+    }
+    pub fn resume<'a>(
+        &self,
+        py: Python<'a>,
+        at_time: Option<Duration>,
+    ) -> PyResult<Bound<'a, PyAny>> {
+        let inner = Arc::clone(&self.inner);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let data = inner.resume(at_time).await;
+            Ok(data.ok())
         })
     }
 }

--- a/src/python/miner.rs
+++ b/src/python/miner.rs
@@ -1,0 +1,57 @@
+use super::data::MinerData;
+use crate::data::device::{MinerFirmware, MinerHardware, MinerMake, MinerModel};
+use crate::miners::backends::traits::Miner as MinerTrait;
+
+use pyo3::prelude::*;
+use std::sync::Arc;
+
+#[pyclass(module = "asic_rs")]
+pub(crate) struct Miner {
+    inner: Arc<Box<dyn MinerTrait>>,
+}
+
+impl Miner {
+    pub fn new(inner: Box<dyn MinerTrait>) -> Self {
+        Self {
+            inner: Arc::new(inner),
+        }
+    }
+}
+
+impl From<Box<dyn MinerTrait>> for Miner {
+    fn from(inner: Box<dyn MinerTrait>) -> Self {
+        Self::new(inner)
+    }
+}
+
+#[pymethods]
+impl Miner {
+    fn __repr__(&self) -> String {
+        format!("{} {} ({})", self.make(), self.model(), self.firmware())
+    }
+
+    #[getter]
+    fn model(&self) -> MinerModel {
+        self.inner.get_device_info().model
+    }
+    #[getter]
+    fn make(&self) -> MinerMake {
+        self.inner.get_device_info().make
+    }
+    #[getter]
+    fn firmware(&self) -> MinerFirmware {
+        self.inner.get_device_info().firmware
+    }
+    #[getter]
+    fn hardware(&self) -> MinerHardware {
+        self.inner.get_device_info().hardware
+    }
+
+    pub fn get_data<'a>(&self, py: Python<'a>) -> PyResult<Bound<'a, PyAny>> {
+        let inner = Arc::clone(&self.inner);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let data = inner.get_data().await;
+            Ok(MinerData::from(&data))
+        })
+    }
+}

--- a/src/python/miner.rs
+++ b/src/python/miner.rs
@@ -1,5 +1,5 @@
 use super::data::{BoardData, FanData, MinerData};
-use crate::data::device::{MinerFirmware, MinerHardware, MinerMake, MinerModel};
+use crate::data::device::{HashAlgorithm, MinerFirmware, MinerHardware, MinerMake, MinerModel};
 use crate::miners::backends::traits::Miner as MinerTrait;
 
 use pyo3::prelude::*;
@@ -42,6 +42,10 @@ impl Miner {
     #[getter]
     fn firmware(&self) -> MinerFirmware {
         self.inner.get_device_info().firmware
+    }
+    #[getter]
+    fn algo(&self) -> HashAlgorithm {
+        self.inner.get_device_info().algo
     }
     #[getter]
     fn hardware(&self) -> MinerHardware {

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -8,4 +8,6 @@ mod miner;
 mod asic_rs {
     #[pymodule_export]
     use super::factory::MinerFactory;
+    #[pymodule_export]
+    use super::miner::Miner;
 }

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -10,4 +10,13 @@ mod asic_rs {
     use super::factory::MinerFactory;
     #[pymodule_export]
     use super::miner::Miner;
+
+    #[pymodule_export]
+    use super::data::HashAlgorithm;
+    #[pymodule_export]
+    use super::data::MinerFirmware;
+    #[pymodule_export]
+    use super::data::MinerMake;
+    #[pymodule_export]
+    use super::data::MinerModel;
 }

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -1,0 +1,11 @@
+use pyo3::prelude::*;
+
+mod data;
+mod factory;
+mod miner;
+
+#[pymodule(module = "asic_rs")]
+mod asic_rs {
+    #[pymodule_export]
+    use super::factory::MinerFactory;
+}


### PR DESCRIPTION
Adds python bindings using `pyo3`.  You can test these bindings by - 

- Creating a python virtual environment in the project (`python3 -m venv .venv`)
- Activating the virtual environment (now located in `.venv`)
- Running `pip install maturin` to install the build tools
- Running `maturin develop` to create a debug build
- Importing and using functionality from `pyasic_rs`, such as `from pyasic_rs.factory import MinerFactory`

This is a hybrid of pyo3 python bindings which give access to the underlying python control functions, and a python library which overlays the functions for better type hinting and pydantic support.