### PR TITLE
bug: fix wm V1 having newlines in some responses

### DIFF
--- a/src/miners/backends/whatsminer/v1/rpc.rs
+++ b/src/miners/backends/whatsminer/v1/rpc.rs
@@ -33,7 +33,9 @@ impl APIClient for WhatsMinerRPCAPI {
 
 impl RPCCommandStatus {
     fn from_btminer_v1(response: &str) -> Result<Self, RPCError> {
-        let parsed: Result<serde_json::Value, _> = serde_json::from_str(response);
+        // Fix for WM V1, can have newlines in version which breaks the json parser
+        let response = response.replace("\n", "");
+        let parsed: Result<serde_json::Value, _> = serde_json::from_str(&response);
 
         if let Ok(data) = &parsed {
             let command_status = data["STATUS"][0]["STATUS"]

--- a/src/miners/util.rs
+++ b/src/miners/util.rs
@@ -61,7 +61,9 @@ pub(crate) async fn send_web_command(
 }
 
 fn parse_rpc_result(response: &str) -> Option<serde_json::Value> {
-    let parsed: Result<serde_json::Value, _> = serde_json::from_str(response);
+    // Fix for WM V1, can have newlines in version which breaks the json parser
+    let response = response.replace("\n", "");
+    let parsed: Result<serde_json::Value, _> = serde_json::from_str(&response);
     let success_codes = ["S", "I"];
 
     match parsed.ok() {


### PR DESCRIPTION
Example response which was causing this - 
```
&response = "{\"STATUS\":\"S\",\"When\":1760998397,\"Code\":131,\"Msg\":{\"api_ver\":\"whatsminer v1.4.0\",\"fw_ver\":\"20210322.22.REL\n\"},\"Description\":\"whatsminer v1.4.0\"}"
```

Specifically the newline in `fw_ver`.