### PR TITLE
bug: fix readme generation

### DIFF
--- a/.github/workflows/readme.yml
+++ b/.github/workflows/readme.yml
@@ -16,4 +16,4 @@ jobs:
         uses: docker://codeberg.org/msrd0/cargo-doc2readme
         with:
           entrypoint: cargo
-          args: doc2readme --check
+          args: doc2readme

--- a/README.md
+++ b/README.md
@@ -121,9 +121,9 @@ async fn main() {
 ```
 
 
- [__cargo_doc2readme_dependencies_info]: ggGkYW0CYXSEG_W_Gn_kaocAGwCcVPfenh7eGy6gYLEwyIe4G6-xw_FwcbpjYXKEG5D_qVKckslCGxwIeK2B_3HPG0dVylfZ-fxqG8PBiqF0DLdRYWSBg2dhc2ljLXJzZTAuMS40Z2FzaWNfcnM
- [__link0]: https://docs.rs/asic-rs/0.1.4/asic_rs/?search=miners::factory::MinerFactory
- [__link1]: https://docs.rs/asic-rs/0.1.4/asic_rs/?search=miners::factory::MinerFactory
- [__link2]: https://docs.rs/asic-rs/0.1.4/asic_rs/?search=data::miner::MinerData
- [__link3]: https://docs.rs/asic-rs/0.1.4/asic_rs/?search=miners::backends::traits::GetMinerData
- [__link4]: https://docs.rs/asic-rs/0.1.4/asic_rs/?search=miners::backends::traits::HasMinerControl
+ [__cargo_doc2readme_dependencies_info]: ggGkYW0CYXSEG_W_Gn_kaocAGwCcVPfenh7eGy6gYLEwyIe4G6-xw_FwcbpjYXKEG5D_qVKckslCGxwIeK2B_3HPG0dVylfZ-fxqG8PBiqF0DLdRYWSBg2dhc2ljLXJzZTAuMS41Z2FzaWNfcnM
+ [__link0]: https://docs.rs/asic-rs/0.1.5/asic_rs/?search=miners::factory::MinerFactory
+ [__link1]: https://docs.rs/asic-rs/0.1.5/asic_rs/?search=miners::factory::MinerFactory
+ [__link2]: https://docs.rs/asic-rs/0.1.5/asic_rs/?search=data::miner::MinerData
+ [__link3]: https://docs.rs/asic-rs/0.1.5/asic_rs/?search=miners::backends::traits::GetMinerData
+ [__link4]: https://docs.rs/asic-rs/0.1.5/asic_rs/?search=miners::backends::traits::HasMinerControl


### PR DESCRIPTION
`doc2readme --check` seems to generate errors for an invalid version being linked, which is not the case.