### PR TITLE
feature: make `select_backend` public

### DIFF
--- a/src/miners/factory/mod.rs
+++ b/src/miners/factory/mod.rs
@@ -162,7 +162,7 @@ fn parse_type_from_web(
 }
 
 #[tracing::instrument(level = "debug")]
-fn select_backend(
+pub fn select_backend(
     ip: IpAddr,
     model: MinerModel,
     firmware: Option<MinerFirmware>,


### PR DESCRIPTION
If a high performance application already knows the version, firmware, model, and IP of a miner, it is much faster to just select the backend rather than having to get the miner each time.