### PR TITLE
fix: handle optional working chips in total chips calculation

### DIFF
--- a/src/miners/backends/traits.rs
+++ b/src/miners/backends/traits.rs
@@ -157,9 +157,7 @@ impl<
         let total_chips = {
             let chips = hashboards
                 .iter()
-                .map(|b| b.working_chips)
-                .filter(|x| x.is_some())
-                .map(|x| x.unwrap())
+                .filter_map(|b| b.working_chips)
                 .collect::<Vec<u16>>();
 
             if !chips.is_empty() {


### PR DESCRIPTION
Before

- total_chips was computed by summing BoardData.working_chips as an Option<u16>.
- Because Rust’s sum() over Option returns None if any element is None, one inactive/non-reporting board (0/1/2) caused total_chips to become None even if the other boards reported valid chip counts.
- Result: total_chips frequently disappeared during partial board failures, reducing observability.

After

- total_chips is now computed by filtering out missing chip counts (working_chips = None) and summing only the reported values.
- The code returns:
  - Some(total) if at least one board reports a chip count
  - None only if no boards report chip counts at all
- Result: total_chips remains populated and useful even when one or more boards are down.