### PR TITLE
bugfix/antminer-sleep-mode-detection

### DIFF
--- a/src/miners/backends/antminer/v2020/mod.rs
+++ b/src/miners/backends/antminer/v2020/mod.rs
@@ -581,7 +581,10 @@ impl GetIsMining for AntMinerV2020 {
         data.extract::<String>(DataField::IsMining)
             .map(|status| {
                 let status_lower = status.to_lowercase();
-                status_lower != "stopped" && status_lower != "idle" && status_lower != "sleep" && status_lower != "1"
+                status_lower != "stopped"
+                    && status_lower != "idle"
+                    && status_lower != "sleep"
+                    && status_lower != "1"
             })
             .or_else(|| data.extract::<f64>(DataField::Hashrate).map(|hr| hr > 0.0))
             .unwrap_or(false)


### PR DESCRIPTION
Fix AntMinerV2020 mining-state detection when bitmain-work-mode is returned as a numeric string. Treat "1" (sleep) as not mining, alongside "stopped", "idle", and "sleep"