### PR TITLE
Fix antminer is_mining to return false when hashrate is zero

### DIFF
--- a/python/pyasic_rs/data.py
+++ b/python/pyasic_rs/data.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 from enum import IntEnum
 from ipaddress import IPv4Address
-from typing import Annotated, Self
+from typing import Annotated, Self, Literal
 
 from pydantic import BaseModel, ConfigDict, BeforeValidator, field_serializer, model_serializer
 
@@ -213,6 +213,7 @@ class MinerData(BaseModel):
     light_flashing: bool | None
     messages: list[MinerMessage]
     uptime: timedelta | None
+    mining_mode: Literal["enabled", "disabled"]
     is_mining: bool
     pools: list[PoolData]
 

--- a/python/pyasic_rs/miner.py
+++ b/python/pyasic_rs/miner.py
@@ -103,6 +103,9 @@ class Miner:
     async def get_uptime(self) -> timedelta | None:
         return await self.__inner.get_uptime()
 
+    async def get_mining_mode(self) -> str:
+        return await self.__inner.get_mining_mode()
+
     async def get_is_mining(self) -> bool | None:
         return await self.__inner.get_is_mining()
 

--- a/src/data/miner.rs
+++ b/src/data/miner.rs
@@ -13,6 +13,8 @@ use macaddr::MacAddr;
 use measurements::{Power, Temperature};
 use serde::{Deserialize, Serialize};
 
+pub use super::mode::MiningMode;
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MinerData {
     /// The schema version of this MinerData object, for use in external APIs
@@ -78,6 +80,8 @@ pub struct MinerData {
     /// The total uptime of the miner's system
     pub uptime: Option<Duration>,
     /// Whether the hashing process is currently running
+    pub mining_mode: MiningMode,
+    /// Whether the miner is currently hashing.
     pub is_mining: bool,
     /// The current pools configured on the miner
     pub pools: Vec<PoolData>,

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -9,5 +9,6 @@ pub mod fan;
 pub mod hashrate;
 pub mod message;
 pub mod miner;
+pub mod mode;
 pub mod pool;
 pub(crate) mod serialize;

--- a/src/data/mode.rs
+++ b/src/data/mode.rs
@@ -1,0 +1,35 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[derive(Default)]
+pub enum MiningMode {
+    #[default]
+    Enabled,
+    Disabled,
+}
+
+impl From<bool> for MiningMode {
+    fn from(value: bool) -> Self {
+        if value {
+            MiningMode::Enabled
+        } else {
+            MiningMode::Disabled
+        }
+    }
+}
+
+impl From<MiningMode> for bool {
+    fn from(value: MiningMode) -> Self {
+        matches!(value, MiningMode::Enabled)
+    }
+}
+
+impl std::fmt::Display for MiningMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MiningMode::Enabled => write!(f, "enabled"),
+            MiningMode::Disabled => write!(f, "disabled"),
+        }
+    }
+}

--- a/src/miners/backends/antminer/v2020/mod.rs
+++ b/src/miners/backends/antminer/v2020/mod.rs
@@ -317,7 +317,7 @@ impl GetDataLocations for AntMinerV2020 {
                     tag: None,
                 },
             )],
-            DataField::IsMining => vec![(
+            DataField::MiningMode => vec![(
                 WEB_MINER_CONF,
                 DataExtractor {
                     func: get_by_pointer,
@@ -333,6 +333,7 @@ impl GetDataLocations for AntMinerV2020 {
                     tag: None,
                 },
             )],
+            DataField::IsMining => vec![],
             DataField::Pools => vec![(
                 RPC_POOLS,
                 DataExtractor {
@@ -526,6 +527,14 @@ impl GetHashrate for AntMinerV2020 {
     }
 }
 
+impl GetIsMining for AntMinerV2020 {
+    fn parse_is_mining(&self, data: &HashMap<DataField, Value>) -> bool {
+        self.parse_hashrate(data)
+            .map(|hr| hr.value > 0.0)
+            .unwrap_or(false)
+    }
+}
+
 impl GetExpectedHashrate for AntMinerV2020 {
     fn parse_expected_hashrate(&self, data: &HashMap<DataField, Value>) -> Option<HashRate> {
         data.extract_map::<f64, _>(DataField::ExpectedHashrate, |f| {
@@ -576,22 +585,24 @@ impl GetUptime for AntMinerV2020 {
     }
 }
 
-impl GetIsMining for AntMinerV2020 {
-    fn parse_is_mining(&self, data: &HashMap<DataField, Value>) -> bool {
-        data.extract::<String>(DataField::IsMining)
+impl GetMiningMode for AntMinerV2020 {
+    fn parse_mining_mode(
+        &self,
+        data: &HashMap<DataField, Value>,
+    ) -> crate::data::miner::MiningMode {
+        let enabled = data
+            .extract::<String>(DataField::MiningMode)
             .map(|status| {
                 let status_lower = status.to_lowercase();
-                (status_lower != "stopped"
+                status_lower != "stopped"
                     && status_lower != "idle"
                     && status_lower != "sleep"
-                    && status_lower != "1")
-                    && data
-                        .extract::<f64>(DataField::Hashrate)
-                        .map(|hr| hr > 0.0)
-                        .unwrap_or(true)
+                    && status_lower != "1"
             })
             .or_else(|| data.extract::<f64>(DataField::Hashrate).map(|hr| hr > 0.0))
-            .unwrap_or(false)
+            .unwrap_or(false);
+
+        enabled.into()
     }
 }
 

--- a/src/miners/backends/avalonminer/avalon_a/mod.rs
+++ b/src/miners/backends/avalonminer/avalon_a/mod.rs
@@ -295,6 +295,7 @@ impl GetDataLocations for AvalonAMiner {
                     tag: None,
                 },
             )],
+            DataField::IsMining => vec![],
             DataField::Pools => vec![(
                 RPC_POOLS,
                 DataExtractor {
@@ -485,6 +486,14 @@ impl GetHashrate for AvalonAMiner {
     }
 }
 
+impl GetIsMining for AvalonAMiner {
+    fn parse_is_mining(&self, data: &HashMap<DataField, Value>) -> bool {
+        self.parse_hashrate(data)
+            .map(|hr| hr.value > 0.0)
+            .unwrap_or(false)
+    }
+}
+
 impl GetExpectedHashrate for AvalonAMiner {
     fn parse_expected_hashrate(&self, data: &HashMap<DataField, Value>) -> Option<HashRate> {
         data.extract_map::<f64, _>(DataField::ExpectedHashrate, |f| HashRate {
@@ -557,7 +566,7 @@ impl GetUptime for AvalonAMiner {
 }
 
 impl GetFluidTemperature for AvalonAMiner {}
-impl GetIsMining for AvalonAMiner {}
+impl GetMiningMode for AvalonAMiner {}
 
 impl GetPools for AvalonAMiner {
     fn parse_pools(&self, data: &HashMap<DataField, Value>) -> Vec<PoolData> {

--- a/src/miners/backends/avalonminer/avalon_q/mod.rs
+++ b/src/miners/backends/avalonminer/avalon_q/mod.rs
@@ -301,6 +301,7 @@ impl GetDataLocations for AvalonQMiner {
                     tag: None,
                 },
             )],
+            DataField::IsMining => vec![],
             DataField::Pools => vec![(
                 RPC_POOLS,
                 DataExtractor {
@@ -461,6 +462,14 @@ impl GetHashrate for AvalonQMiner {
     }
 }
 
+impl GetIsMining for AvalonQMiner {
+    fn parse_is_mining(&self, data: &HashMap<DataField, Value>) -> bool {
+        self.parse_hashrate(data)
+            .map(|hr| hr.value > 0.0)
+            .unwrap_or(false)
+    }
+}
+
 impl GetExpectedHashrate for AvalonQMiner {
     fn parse_expected_hashrate(&self, data: &HashMap<DataField, Value>) -> Option<HashRate> {
         data.extract_map::<f64, _>(DataField::ExpectedHashrate, |f| HashRate {
@@ -527,7 +536,7 @@ impl GetUptime for AvalonQMiner {
 }
 
 impl GetFluidTemperature for AvalonQMiner {}
-impl GetIsMining for AvalonQMiner {}
+impl GetMiningMode for AvalonQMiner {}
 
 impl GetPools for AvalonQMiner {
     fn parse_pools(&self, data: &HashMap<DataField, Value>) -> Vec<PoolData> {

--- a/src/miners/backends/bitaxe/v2_0_0/mod.rs
+++ b/src/miners/backends/bitaxe/v2_0_0/mod.rs
@@ -163,6 +163,7 @@ impl GetDataLocations for Bitaxe200 {
                     tag: None,
                 },
             )],
+            DataField::IsMining => vec![],
             DataField::Pools => vec![(
                 WEB_SYSTEM_INFO,
                 DataExtractor {
@@ -315,6 +316,15 @@ impl GetHashrate for Bitaxe200 {
         })
     }
 }
+
+impl GetIsMining for Bitaxe200 {
+    fn parse_is_mining(&self, data: &HashMap<DataField, Value>) -> bool {
+        self.parse_hashrate(data)
+            .map(|hr| hr.value > 0.0)
+            .unwrap_or(false)
+    }
+}
+
 impl GetExpectedHashrate for Bitaxe200 {
     fn parse_expected_hashrate(&self, data: &HashMap<DataField, Value>) -> Option<HashRate> {
         let total_chips =
@@ -396,10 +406,14 @@ impl GetUptime for Bitaxe200 {
         data.extract_map::<u64, _>(DataField::Uptime, Duration::from_secs)
     }
 }
-impl GetIsMining for Bitaxe200 {
-    fn parse_is_mining(&self, data: &HashMap<DataField, Value>) -> bool {
+impl GetMiningMode for Bitaxe200 {
+    fn parse_mining_mode(
+        &self,
+        data: &HashMap<DataField, Value>,
+    ) -> crate::data::miner::MiningMode {
         let hashrate = self.parse_hashrate(data);
-        hashrate.as_ref().is_some_and(|hr| hr.value > 0.0)
+        let enabled = hashrate.as_ref().is_some_and(|hr| hr.value > 0.0);
+        enabled.into()
     }
 }
 impl GetPools for Bitaxe200 {

--- a/src/miners/backends/bitaxe/v2_9_0/mod.rs
+++ b/src/miners/backends/bitaxe/v2_9_0/mod.rs
@@ -176,6 +176,7 @@ impl GetDataLocations for Bitaxe290 {
                     tag: None,
                 },
             )],
+            DataField::IsMining => vec![],
             DataField::Pools => vec![(
                 WEB_SYSTEM_INFO,
                 DataExtractor {
@@ -322,6 +323,14 @@ impl GetHashrate for Bitaxe290 {
     }
 }
 
+impl GetIsMining for Bitaxe290 {
+    fn parse_is_mining(&self, data: &HashMap<DataField, Value>) -> bool {
+        self.parse_hashrate(data)
+            .map(|hr| hr.value > 0.0)
+            .unwrap_or(false)
+    }
+}
+
 impl GetExpectedHashrate for Bitaxe290 {
     fn parse_expected_hashrate(&self, data: &HashMap<DataField, Value>) -> Option<HashRate> {
         data.extract_map::<f64, _>(DataField::ExpectedHashrate, |f| HashRate {
@@ -384,10 +393,14 @@ impl GetUptime for Bitaxe290 {
         data.extract_map::<u64, _>(DataField::Uptime, Duration::from_secs)
     }
 }
-impl GetIsMining for Bitaxe290 {
-    fn parse_is_mining(&self, data: &HashMap<DataField, Value>) -> bool {
+impl GetMiningMode for Bitaxe290 {
+    fn parse_mining_mode(
+        &self,
+        data: &HashMap<DataField, Value>,
+    ) -> crate::data::miner::MiningMode {
         let hashrate = self.parse_hashrate(data);
-        hashrate.as_ref().is_some_and(|hr| hr.value > 0.0)
+        let enabled = hashrate.as_ref().is_some_and(|hr| hr.value > 0.0);
+        enabled.into()
     }
 }
 impl GetPools for Bitaxe290 {

--- a/src/miners/backends/epic/v1/mod.rs
+++ b/src/miners/backends/epic/v1/mod.rs
@@ -193,6 +193,7 @@ impl GetDataLocations for PowerPlayV1 {
                     },
                 ),
             ],
+            DataField::IsMining => vec![],
             DataField::Pools => vec![(
                 WEB_SUMMARY,
                 DataExtractor {
@@ -201,7 +202,7 @@ impl GetDataLocations for PowerPlayV1 {
                     tag: None,
                 },
             )],
-            DataField::IsMining => vec![(
+            DataField::MiningMode => vec![(
                 WEB_SUMMARY,
                 DataExtractor {
                     func: get_by_pointer,
@@ -652,6 +653,14 @@ impl GetHashrate for PowerPlayV1 {
     }
 }
 
+impl GetIsMining for PowerPlayV1 {
+    fn parse_is_mining(&self, data: &HashMap<DataField, Value>) -> bool {
+        self.parse_hashrate(data)
+            .map(|hr| hr.value > 0.0)
+            .unwrap_or(false)
+    }
+}
+
 impl GetExpectedHashrate for PowerPlayV1 {
     fn parse_expected_hashrate(&self, data: &HashMap<DataField, Value>) -> Option<HashRate> {
         data.extract_map::<f64, _>(DataField::ExpectedHashrate, |f| HashRate {
@@ -715,11 +724,16 @@ impl GetUptime for PowerPlayV1 {
     }
 }
 
-impl GetIsMining for PowerPlayV1 {
-    fn parse_is_mining(&self, data: &HashMap<DataField, Value>) -> bool {
-        data.extract::<String>(DataField::IsMining)
+impl GetMiningMode for PowerPlayV1 {
+    fn parse_mining_mode(
+        &self,
+        data: &HashMap<DataField, Value>,
+    ) -> crate::data::miner::MiningMode {
+        let enabled = data
+            .extract::<String>(DataField::MiningMode)
             .map(|state| state != "Idling")
-            .unwrap_or(false)
+            .unwrap_or(false);
+        enabled.into()
     }
 }
 

--- a/src/miners/backends/luxminer/v1/mod.rs
+++ b/src/miners/backends/luxminer/v1/mod.rs
@@ -283,7 +283,7 @@ impl GetDataLocations for LuxMinerV1 {
                     tag: None,
                 },
             )],
-            DataField::IsMining => vec![(
+            DataField::MiningMode => vec![(
                 RPC_SUMMARY,
                 DataExtractor {
                     func: get_by_pointer,
@@ -299,6 +299,7 @@ impl GetDataLocations for LuxMinerV1 {
                     tag: None,
                 },
             )],
+            DataField::IsMining => vec![],
             DataField::Pools => vec![(
                 RPC_POOLS,
                 DataExtractor {
@@ -742,6 +743,14 @@ impl GetHashrate for LuxMinerV1 {
     }
 }
 
+impl GetIsMining for LuxMinerV1 {
+    fn parse_is_mining(&self, data: &HashMap<DataField, Value>) -> bool {
+        self.parse_hashrate(data)
+            .map(|hr| hr.value > 0.0)
+            .unwrap_or(false)
+    }
+}
+
 impl GetExpectedHashrate for LuxMinerV1 {
     fn parse_expected_hashrate(&self, data: &HashMap<DataField, Value>) -> Option<HashRate> {
         let data = data
@@ -802,11 +811,16 @@ impl GetUptime for LuxMinerV1 {
     }
 }
 
-impl GetIsMining for LuxMinerV1 {
-    fn parse_is_mining(&self, data: &HashMap<DataField, Value>) -> bool {
-        data.extract::<f64>(DataField::IsMining)
+impl GetMiningMode for LuxMinerV1 {
+    fn parse_mining_mode(
+        &self,
+        data: &HashMap<DataField, Value>,
+    ) -> crate::data::miner::MiningMode {
+        let enabled = data
+            .extract::<f64>(DataField::MiningMode)
             .map(|hr| hr > 0.0)
-            .unwrap_or(false)
+            .unwrap_or(false);
+        enabled.into()
     }
 }
 

--- a/src/miners/backends/marathon/v1/mod.rs
+++ b/src/miners/backends/marathon/v1/mod.rs
@@ -358,7 +358,7 @@ impl GetDataLocations for MaraV1 {
                     tag: None,
                 },
             )],
-            DataField::IsMining => vec![(
+            DataField::MiningMode => vec![(
                 WEB_BRIEF,
                 DataExtractor {
                     func: get_by_pointer,
@@ -374,6 +374,7 @@ impl GetDataLocations for MaraV1 {
                     tag: None,
                 },
             )],
+            DataField::IsMining => vec![],
             DataField::Pools => vec![(
                 WEB_POOLS,
                 DataExtractor {
@@ -629,6 +630,14 @@ impl GetHashrate for MaraV1 {
     }
 }
 
+impl GetIsMining for MaraV1 {
+    fn parse_is_mining(&self, data: &HashMap<DataField, Value>) -> bool {
+        self.parse_hashrate(data)
+            .map(|hr| hr.value > 0.0)
+            .unwrap_or(false)
+    }
+}
+
 impl GetExpectedHashrate for MaraV1 {
     fn parse_expected_hashrate(&self, data: &HashMap<DataField, Value>) -> Option<HashRate> {
         data.extract::<f64>(DataField::ExpectedHashrate)
@@ -744,11 +753,16 @@ impl GetUptime for MaraV1 {
     }
 }
 
-impl GetIsMining for MaraV1 {
-    fn parse_is_mining(&self, data: &HashMap<DataField, Value>) -> bool {
-        data.extract::<String>(DataField::IsMining)
+impl GetMiningMode for MaraV1 {
+    fn parse_mining_mode(
+        &self,
+        data: &HashMap<DataField, Value>,
+    ) -> crate::data::miner::MiningMode {
+        let enabled = data
+            .extract::<String>(DataField::MiningMode)
             .map(|status| status == "Mining")
-            .unwrap_or(false)
+            .unwrap_or(false);
+        enabled.into()
     }
 }
 

--- a/src/miners/backends/nerdaxe/mod.rs
+++ b/src/miners/backends/nerdaxe/mod.rs
@@ -171,6 +171,7 @@ impl GetDataLocations for NerdAxeV1 {
                     tag: None,
                 },
             )],
+            DataField::IsMining => vec![],
             DataField::Pools => vec![(
                 WEB_SYSTEM_INFO,
                 DataExtractor {
@@ -320,6 +321,15 @@ impl GetHashrate for NerdAxeV1 {
         })
     }
 }
+
+impl GetIsMining for NerdAxeV1 {
+    fn parse_is_mining(&self, data: &HashMap<DataField, Value>) -> bool {
+        self.parse_hashrate(data)
+            .map(|hr| hr.value > 0.0)
+            .unwrap_or(false)
+    }
+}
+
 impl GetExpectedHashrate for NerdAxeV1 {
     fn parse_expected_hashrate(&self, data: &HashMap<DataField, Value>) -> Option<HashRate> {
         let total_chips =
@@ -393,10 +403,14 @@ impl GetUptime for NerdAxeV1 {
         data.extract_map::<u64, _>(DataField::Uptime, Duration::from_secs)
     }
 }
-impl GetIsMining for NerdAxeV1 {
-    fn parse_is_mining(&self, data: &HashMap<DataField, Value>) -> bool {
+impl GetMiningMode for NerdAxeV1 {
+    fn parse_mining_mode(
+        &self,
+        data: &HashMap<DataField, Value>,
+    ) -> crate::data::miner::MiningMode {
         let hashrate = self.parse_hashrate(data);
-        hashrate.as_ref().is_some_and(|hr| hr.value > 0.0)
+        let enabled = hashrate.as_ref().is_some_and(|hr| hr.value > 0.0);
+        enabled.into()
     }
 }
 impl GetPools for NerdAxeV1 {

--- a/src/miners/backends/whatsminer/v3/mod.rs
+++ b/src/miners/backends/whatsminer/v3/mod.rs
@@ -177,6 +177,7 @@ impl GetDataLocations for WhatsMinerV3 {
                     },
                 ),
             ],
+            DataField::IsMining => vec![],
             DataField::Pools => vec![(
                 rpc_get_miner_status_pools,
                 DataExtractor {
@@ -361,6 +362,15 @@ impl GetHashrate for WhatsMinerV3 {
         })
     }
 }
+
+impl GetIsMining for WhatsMinerV3 {
+    fn parse_is_mining(&self, data: &HashMap<DataField, Value>) -> bool {
+        self.parse_hashrate(data)
+            .map(|hr| hr.value > 0.0)
+            .unwrap_or(false)
+    }
+}
+
 impl GetExpectedHashrate for WhatsMinerV3 {
     fn parse_expected_hashrate(&self, data: &HashMap<DataField, Value>) -> Option<HashRate> {
         data.extract_map::<f64, _>(DataField::ExpectedHashrate, |f| HashRate {
@@ -429,7 +439,7 @@ impl GetUptime for WhatsMinerV3 {
         data.extract_map::<u64, _>(DataField::Uptime, Duration::from_secs)
     }
 }
-impl GetIsMining for WhatsMinerV3 {}
+impl GetMiningMode for WhatsMinerV3 {}
 impl GetPools for WhatsMinerV3 {
     fn parse_pools(&self, data: &HashMap<DataField, Value>) -> Vec<PoolData> {
         let mut pools: Vec<PoolData> = Vec::new();

--- a/src/miners/data.rs
+++ b/src/miners/data.rs
@@ -55,6 +55,8 @@ pub enum DataField {
     Messages,
     /// Uptime in seconds.
     Uptime,
+    /// Whether mining is enabled (i.e., not sleeping/paused/stopped).
+    MiningMode,
     /// Whether the miner is currently hashing.
     IsMining,
     /// Pool configuration (addresses, statuses, etc.).
@@ -275,8 +277,10 @@ impl<'a> DataCollector<'a> {
 
     /// Collects **all** available fields from the miner and returns a map of results.
     pub async fn collect_all(&mut self) -> HashMap<DataField, Value> {
-        self.collect(DataField::iter().collect::<Vec<_>>().as_slice())
-            .await
+        let fields = DataField::iter()
+            .filter(|f| *f != DataField::IsMining)
+            .collect::<Vec<_>>();
+        self.collect(fields.as_slice()).await
     }
 
     /// Collects only the specified fields from the miner and returns a map of results.

--- a/src/python/data.rs
+++ b/src/python/data.rs
@@ -122,6 +122,7 @@ pub struct MinerData {
     pub light_flashing: Option<bool>,
     pub messages: Vec<MinerMessage>,
     pub uptime: Option<Duration>,
+    pub mining_mode: String,
     pub is_mining: bool,
     pub pools: Vec<PoolData>,
 }
@@ -156,6 +157,7 @@ impl From<&MinerData_Base> for MinerData {
             light_flashing: base.light_flashing,
             messages: base.messages.clone(),
             uptime: base.uptime,
+            mining_mode: base.mining_mode.to_string(),
             is_mining: base.is_mining,
             pools: base.pools.clone(),
         }

--- a/src/python/miner.rs
+++ b/src/python/miner.rs
@@ -209,6 +209,14 @@ impl Miner {
             Ok(data)
         })
     }
+    pub fn get_mining_mode<'a>(&self, py: Python<'a>) -> PyResult<Bound<'a, PyAny>> {
+        let inner = Arc::clone(&self.inner);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let data = inner.get_mining_mode().await;
+            Ok(data.to_string())
+        })
+    }
+
     pub fn get_is_mining<'a>(&self, py: Python<'a>) -> PyResult<Bound<'a, PyAny>> {
         let inner = Arc::clone(&self.inner);
         pyo3_async_runtimes::tokio::future_into_py(py, async move {


### PR DESCRIPTION
Issue: bitmain-work-mode can show normal ("0") even when the miner is overheated and has 0 hashrate, so is_mining ends up true.

Fix: Only report is_mining as true when hashrate is > 0 (when hashrate is available). This keeps the existing work-mode checks and stops the false “mining” state at zero hashrate.