### PR TITLE
fix: fix failed `model_validate` call when calling `get_data` from python

### DIFF
--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -27,4 +27,7 @@ mod asic_rs {
     use super::data::MinerMake;
     #[pymodule_export]
     use super::data::MinerModel;
+
+    #[pymodule_export]
+    use crate::data::hashrate::HashRateUnit;
 }


### PR DESCRIPTION
This occurred on any data including `HashRate`, since the latest version of maturin seems to break `BeforeValidator` from pydantic in annotations.