### PR TITLE
feat: re-export core and firmware crates via asic-rs features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,7 @@ panic = "warn"
 
 [features]
 default = [
+    "core",
     "antminer",
     "avalonminer",
     "bitaxe",
@@ -117,6 +118,7 @@ default = [
     "whatsminer",
 ]
 
+core = []
 antminer = ["dep:asic-rs-firmwares-antminer"]
 avalonminer = ["dep:asic-rs-firmwares-avalonminer"]
 bitaxe = ["dep:asic-rs-firmwares-bitaxe"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,6 +209,30 @@
 pub use factory::MinerFactory;
 pub use listener::MinerListener;
 
+#[cfg(feature = "core")]
+pub use asic_rs_core as core;
+
+#[cfg(feature = "antminer")]
+pub use asic_rs_firmwares_antminer as antminer;
+#[cfg(feature = "avalonminer")]
+pub use asic_rs_firmwares_avalonminer as avalonminer;
+#[cfg(feature = "bitaxe")]
+pub use asic_rs_firmwares_bitaxe as bitaxe;
+#[cfg(feature = "braiins")]
+pub use asic_rs_firmwares_braiins as braiins;
+#[cfg(feature = "epic")]
+pub use asic_rs_firmwares_epic as epic;
+#[cfg(feature = "luxminer")]
+pub use asic_rs_firmwares_luxminer as luxminer;
+#[cfg(feature = "marathon")]
+pub use asic_rs_firmwares_marathon as marathon;
+#[cfg(feature = "nerdaxe")]
+pub use asic_rs_firmwares_nerdaxe as nerdaxe;
+#[cfg(feature = "vnish")]
+pub use asic_rs_firmwares_vnish as vnish;
+#[cfg(feature = "whatsminer")]
+pub use asic_rs_firmwares_whatsminer as whatsminer;
+
 pub mod factory;
 pub mod listener;
 #[cfg(feature = "python")]


### PR DESCRIPTION
## Summary
- add a new `core` feature in `asic-rs` and re-export `asic_rs_core` as `asic_rs::core`
- re-export each firmware crate from `asic-rs` under the existing feature flags (for example `asic_rs::antminer`)
- keep users on a single dependency (`asic-rs`) while selecting firmware support with features