### PR TITLE
fix(epic): detect xilinx control boards in v1 backend

### DIFF
--- a/asic-rs-firmwares/epic/src/backends/v1/mod.rs
+++ b/asic-rs-firmwares/epic/src/backends/v1/mod.rs
@@ -459,6 +459,9 @@ impl GetControlBoardVersion for PowerPlayV1 {
             s if s.to_uppercase().contains("GENERIC AM33XX") => {
                 Some(AntMinerControlBoard::BeagleBoneBlack).map(|cb| cb.into())
             }
+            s if s.to_uppercase().contains("XILINX") => {
+                Some(AntMinerControlBoard::Xilinx).map(|cb| cb.into())
+            }
             _ => Some(EPicControlBoard::EPicUMC).map(|cb| cb.into()),
         }
     }


### PR DESCRIPTION
## Summary
- add explicit detection for Xilinx-based control boards in the EPic v1 backend version parser
- map matched platforms to `AntMinerControlBoard::Xilinx` instead of falling back to `EPicUMC`
- preserve existing behavior for other known and unknown board strings