### PR TITLE
chore(epic): update firmware name to umc os from epic

### DIFF
--- a/asic-rs-firmwares/epic/src/firmware.rs
+++ b/asic-rs-firmwares/epic/src/firmware.rs
@@ -65,7 +65,7 @@ pub struct EPicFirmware {}
 
 impl Display for EPicFirmware {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "ePIC")
+        write!(f, "UMC OS")
     }
 }
 


### PR DESCRIPTION
##Summary

Update the displayed name for the `ePIC` firmware to `UMC OS` to align with the product's actual name.