### PR TITLE
fix(braiins,vnish): refresh expired bearer tokens on 401

### DIFF
--- a/asic-rs-firmwares/braiins/src/backends/v25_07/web.rs
+++ b/asic-rs-firmwares/braiins/src/backends/v25_07/web.rs
@@ -54,7 +54,15 @@ impl WebAPIClient for BraiinsWebAPI {
 
         let url = format!("http://{}:{}/api/v1/{}", self.ip, self.port, command);
 
-        let response = self.execute_request(&url, &method, parameters).await?;
+        let mut response = self
+            .execute_request(&url, &method, parameters.clone())
+            .await?;
+
+        if response.status().as_u16() == 401 {
+            *self.bearer_token.write().await = None;
+            self.ensure_authenticated().await?;
+            response = self.execute_request(&url, &method, parameters).await?;
+        }
 
         let status = response.status();
         if status.is_success() {
@@ -64,7 +72,11 @@ impl WebAPIClient for BraiinsWebAPI {
                 .map_err(|e| BraiinsError::ParseError(e.to_string()))?;
             Ok(json_data)
         } else {
-            Err(BraiinsError::HttpError(status.as_u16()))?
+            let code = status.as_u16();
+            Err(match code {
+                401 => BraiinsError::Unauthorized,
+                _ => BraiinsError::HttpError(code),
+            })?
         }
     }
 }

--- a/asic-rs-firmwares/vnish/src/backends/v1_2_0/web.rs
+++ b/asic-rs-firmwares/vnish/src/backends/v1_2_0/web.rs
@@ -53,7 +53,15 @@ impl WebAPIClient for VnishWebAPI {
 
         let url = format!("http://{}:{}/api/v1/{}", self.ip, self.port, command);
 
-        let response = self.execute_request(&url, &method, parameters).await?;
+        let mut response = self
+            .execute_request(&url, &method, parameters.clone())
+            .await?;
+
+        if response.status().as_u16() == 401 {
+            *self.bearer_token.write().await = None;
+            self.ensure_authenticated().await?;
+            response = self.execute_request(&url, &method, parameters).await?;
+        }
 
         let status = response.status();
         if status.is_success() {
@@ -63,7 +71,11 @@ impl WebAPIClient for VnishWebAPI {
                 .map_err(|e| VnishError::ParseError(e.to_string()))?;
             Ok(json_data)
         } else {
-            Err(VnishError::HttpError(status.as_u16()))?
+            let code = status.as_u16();
+            Err(match code {
+                401 => VnishError::Unauthorized,
+                _ => VnishError::HttpError(code),
+            })?
         }
     }
 }


### PR DESCRIPTION
The cached bearer token is never re-validated, so once the miner expires it server-side (e.g. reboot), every subsequent call returns 401 and the client is stuck until the process restarts. On 401, `send_command` now invalidates the cached token, re-authenticates via the existing `authenticate()`, and retries the request once.