### PR TITLE
feat: add scaled tuning target support

### DIFF
--- a/asic-rs-core/src/data/miner.rs
+++ b/asic-rs-core/src/data/miner.rs
@@ -113,6 +113,8 @@ pub struct MinerData {
     pub wattage: Option<Power>,
     /// The current tuning target of the miner, such as power target or hashrate target
     pub tuning_target: Option<TuningTarget>,
+    /// The current tuning target adjusted by scaling settings, when available.
+    pub scaled_tuning_target: Option<TuningTarget>,
     /// The current efficiency in W/TH/s (J/TH) of the miner
     pub efficiency: Option<f64>,
     /// The state of the fault/alert light on the miner

--- a/asic-rs-core/src/traits/miner.rs
+++ b/asic-rs-core/src/traits/miner.rs
@@ -129,6 +129,7 @@ pub trait GetMinerData:
     + GetFluidTemperature
     + GetWattage
     + GetTuningTarget
+    + GetScaledTuningTarget
     + GetLightFlashing
     + GetMessages
     + GetUptime
@@ -186,6 +187,7 @@ impl<
         + GetFluidTemperature
         + GetWattage
         + GetTuningTarget
+        + GetScaledTuningTarget
         + GetLightFlashing
         + GetMessages
         + GetUptime
@@ -221,6 +223,7 @@ impl<
         let expected_hashrate = self.parse_expected_hashrate(&data);
         let wattage = self.parse_wattage(&data);
         let tuning_target = self.parse_tuning_target(&data);
+        let scaled_tuning_target = self.parse_scaled_tuning_target(&data);
         let fluid_temperature = self.parse_fluid_temperature(&data);
         let fans = self.parse_fans(&data);
         let psu_fans = self.parse_psu_fans(&data);
@@ -311,6 +314,7 @@ impl<
             // Power information
             wattage,
             tuning_target,
+            scaled_tuning_target,
             efficiency,
 
             // Status information
@@ -613,6 +617,22 @@ pub trait GetTuningTarget: CollectData {
     }
     #[allow(unused_variables)]
     fn parse_tuning_target(&self, data: &HashMap<DataField, Value>) -> Option<TuningTarget> {
+        None
+    }
+}
+
+// Scaled Tuning Target
+#[async_trait]
+pub trait GetScaledTuningTarget: CollectData {
+    #[tracing::instrument(level = "debug")]
+    async fn get_scaled_tuning_target(&self) -> Option<TuningTarget> {
+        let mut collector = self.get_collector();
+        let data = collector.collect(&[DataField::TuningTarget]).await;
+        self.parse_scaled_tuning_target(&data)
+    }
+
+    #[allow(unused_variables)]
+    fn parse_scaled_tuning_target(&self, data: &HashMap<DataField, Value>) -> Option<TuningTarget> {
         None
     }
 }

--- a/asic-rs-firmwares/antminer/src/backends/v2020/mod.rs
+++ b/asic-rs-firmwares/antminer/src/backends/v2020/mod.rs
@@ -762,6 +762,8 @@ impl GetWattage for AntMinerV2020 {
 
 impl GetTuningTarget for AntMinerV2020 {}
 
+impl GetScaledTuningTarget for AntMinerV2020 {}
+
 impl GetFluidTemperature for AntMinerV2020 {
     fn parse_fluid_temperature(&self, data: &HashMap<DataField, Value>) -> Option<Temperature> {
         // For S21+ Hyd models, use inlet/outlet temperature average

--- a/asic-rs-firmwares/antminer/src/backends/v2023_07/mod.rs
+++ b/asic-rs-firmwares/antminer/src/backends/v2023_07/mod.rs
@@ -673,6 +673,8 @@ impl GetWattage for AntMinerV202307 {
 
 impl GetTuningTarget for AntMinerV202307 {}
 
+impl GetScaledTuningTarget for AntMinerV202307 {}
+
 impl GetFluidTemperature for AntMinerV202307 {
     fn parse_fluid_temperature(&self, data: &HashMap<DataField, Value>) -> Option<Temperature> {
         // For S21+ Hyd models, use inlet/outlet temperature average

--- a/asic-rs-firmwares/auradine/src/backends/v1/mod.rs
+++ b/asic-rs-firmwares/auradine/src/backends/v1/mod.rs
@@ -1104,6 +1104,8 @@ impl GetTuningTarget for AuradineV1 {
     }
 }
 
+impl GetScaledTuningTarget for AuradineV1 {}
+
 impl GetLightFlashing for AuradineV1 {
     fn parse_light_flashing(&self, data: &HashMap<DataField, Value>) -> Option<bool> {
         data.extract_map::<u64, _>(DataField::LightFlashing, |code| code == 3)

--- a/asic-rs-firmwares/avalonminer/src/backends/avalon_a/mod.rs
+++ b/asic-rs-firmwares/avalonminer/src/backends/avalon_a/mod.rs
@@ -638,6 +638,8 @@ impl GetTuningTarget for AvalonAMiner {
     }
 }
 
+impl GetScaledTuningTarget for AvalonAMiner {}
+
 impl GetLightFlashing for AvalonAMiner {
     fn parse_light_flashing(&self, data: &HashMap<DataField, Value>) -> Option<bool> {
         data.extract::<bool>(DataField::LightFlashing)

--- a/asic-rs-firmwares/avalonminer/src/backends/avalon_q/mod.rs
+++ b/asic-rs-firmwares/avalonminer/src/backends/avalon_q/mod.rs
@@ -617,6 +617,8 @@ impl GetTuningTarget for AvalonQMiner {
     }
 }
 
+impl GetScaledTuningTarget for AvalonQMiner {}
+
 impl GetLightFlashing for AvalonQMiner {
     fn parse_light_flashing(&self, data: &HashMap<DataField, Value>) -> Option<bool> {
         data.extract::<bool>(DataField::LightFlashing)

--- a/asic-rs-firmwares/bitaxe/src/backends/v2_0_0/mod.rs
+++ b/asic-rs-firmwares/bitaxe/src/backends/v2_0_0/mod.rs
@@ -377,6 +377,9 @@ impl GetWattage for Bitaxe200 {
 impl GetTuningTarget for Bitaxe200 {
     // N/A
 }
+impl GetScaledTuningTarget for Bitaxe200 {
+    // N/A
+}
 impl GetLightFlashing for Bitaxe200 {
     // N/A
 }

--- a/asic-rs-firmwares/bitaxe/src/backends/v2_9_0/mod.rs
+++ b/asic-rs-firmwares/bitaxe/src/backends/v2_9_0/mod.rs
@@ -362,6 +362,9 @@ impl GetWattage for Bitaxe290 {
 impl GetTuningTarget for Bitaxe290 {
     // N/A
 }
+impl GetScaledTuningTarget for Bitaxe290 {
+    // N/A
+}
 impl GetLightFlashing for Bitaxe290 {
     // N/A
 }

--- a/asic-rs-firmwares/braiins/src/backends/v21_09/mod.rs
+++ b/asic-rs-firmwares/braiins/src/backends/v21_09/mod.rs
@@ -477,6 +477,8 @@ impl GetTuningTarget for BraiinsV2109 {
     }
 }
 
+impl GetScaledTuningTarget for BraiinsV2109 {}
+
 impl GetLightFlashing for BraiinsV2109 {
     fn parse_light_flashing(&self, data: &HashMap<DataField, Value>) -> Option<bool> {
         data.extract::<bool>(DataField::LightFlashing)

--- a/asic-rs-firmwares/braiins/src/backends/v25_03/mod.rs
+++ b/asic-rs-firmwares/braiins/src/backends/v25_03/mod.rs
@@ -475,6 +475,8 @@ impl GetTuningTarget for BraiinsV2503 {
     }
 }
 
+impl GetScaledTuningTarget for BraiinsV2503 {}
+
 impl GetLightFlashing for BraiinsV2503 {
     fn parse_light_flashing(&self, data: &HashMap<DataField, Value>) -> Option<bool> {
         data.extract::<bool>(DataField::LightFlashing)

--- a/asic-rs-firmwares/braiins/src/backends/v25_05/mod.rs
+++ b/asic-rs-firmwares/braiins/src/backends/v25_05/mod.rs
@@ -481,6 +481,8 @@ impl GetTuningTarget for BraiinsV2505 {
     }
 }
 
+impl GetScaledTuningTarget for BraiinsV2505 {}
+
 impl GetLightFlashing for BraiinsV2505 {
     fn parse_light_flashing(&self, data: &HashMap<DataField, Value>) -> Option<bool> {
         data.extract::<bool>(DataField::LightFlashing)

--- a/asic-rs-firmwares/braiins/src/backends/v25_07/mod.rs
+++ b/asic-rs-firmwares/braiins/src/backends/v25_07/mod.rs
@@ -547,6 +547,8 @@ impl GetTuningTarget for BraiinsV2507 {
     }
 }
 
+impl GetScaledTuningTarget for BraiinsV2507 {}
+
 impl GetFluidTemperature for BraiinsV2507 {}
 
 impl GetPsuFans for BraiinsV2507 {}

--- a/asic-rs-firmwares/braiins/src/backends/v26_04/mod.rs
+++ b/asic-rs-firmwares/braiins/src/backends/v26_04/mod.rs
@@ -543,6 +543,8 @@ impl GetTuningTarget for BraiinsV2604 {
     }
 }
 
+impl GetScaledTuningTarget for BraiinsV2604 {}
+
 impl GetFluidTemperature for BraiinsV2604 {}
 
 impl GetPsuFans for BraiinsV2604 {}

--- a/asic-rs-firmwares/epic/src/backends/v1/mod.rs
+++ b/asic-rs-firmwares/epic/src/backends/v1/mod.rs
@@ -826,6 +826,34 @@ fn parse_tuning_target_from_stats(
     algorithm_drives_power: bool,
 ) -> Option<TuningTarget> {
     let target = tuning_value_as_f64(stats.get("Target")?)?;
+    parse_tuning_target_value_from_stats(summary, algorithm, stats, target, algorithm_drives_power)
+}
+
+fn parse_scaled_tuning_target_from_stats(
+    summary: &Value,
+    algorithm: &str,
+    stats: &Value,
+    algorithm_drives_power: bool,
+) -> Option<TuningTarget> {
+    let throttle_target = stats.get("Throttle Target").and_then(tuning_value_as_f64);
+    let error_throttle_target = stats
+        .get("Error Throttle Target")
+        .and_then(tuning_value_as_f64);
+    let target = [throttle_target, error_throttle_target]
+        .into_iter()
+        .flatten()
+        .min_by(f64::total_cmp)?;
+
+    parse_tuning_target_value_from_stats(summary, algorithm, stats, target, algorithm_drives_power)
+}
+
+fn parse_tuning_target_value_from_stats(
+    summary: &Value,
+    algorithm: &str,
+    stats: &Value,
+    target: f64,
+    algorithm_drives_power: bool,
+) -> Option<TuningTarget> {
     let unit = stats
         .get("Unit")
         .and_then(Value::as_str)
@@ -876,6 +904,22 @@ impl GetTuningTarget for PowerPlayV1 {
 
             let (algorithm, stats) = first_perpetual_tune_algorithm(summary)?;
             parse_tuning_target_from_stats(summary, algorithm, stats, true)
+        })
+    }
+}
+
+impl GetScaledTuningTarget for PowerPlayV1 {
+    fn parse_scaled_tuning_target(&self, data: &HashMap<DataField, Value>) -> Option<TuningTarget> {
+        data.get(&DataField::TuningTarget).and_then(|summary| {
+            if !summary
+                .pointer("/PerpetualTune/Running")
+                .and_then(Value::as_bool)?
+            {
+                return None;
+            }
+
+            let (algorithm, stats) = first_perpetual_tune_algorithm(summary)?;
+            parse_scaled_tuning_target_from_stats(summary, algorithm, stats, true)
         })
     }
 }
@@ -1603,6 +1647,64 @@ mod tests {
         assert_eq!(config.step, 5);
 
         Ok(())
+    }
+
+    #[test]
+    fn parse_scaled_tuning_target_uses_lower_throttle_target() {
+        let miner = PowerPlayV1::new(IpAddr::from([127, 0, 0, 1]), AntMinerModel::S19XP);
+        let summary = serde_json::json!({
+            "Mining": {
+                "Algorithm": "SHA-256"
+            },
+            "PerpetualTune": {
+                "Running": true,
+                "Algorithm": {
+                    "VoltageOptimizer": {
+                        "Target": 143,
+                        "Throttle Target": 120,
+                        "Error Throttle Target": 95,
+                        "Unit": "TH/s"
+                    }
+                }
+            }
+        });
+        let data = HashMap::from([(DataField::TuningTarget, summary)]);
+
+        assert_eq!(
+            miner.parse_scaled_tuning_target(&data),
+            Some(TuningTarget::HashRate(HashRate {
+                value: 95.0,
+                unit: HashRateUnit::TeraHash,
+                algo: "SHA-256".to_string(),
+            }))
+        );
+    }
+
+    #[test]
+    fn parse_scaled_tuning_target_uses_lower_power_throttle_target() {
+        let miner = PowerPlayV1::new(IpAddr::from([127, 0, 0, 1]), AntMinerModel::S19XP);
+        let summary = serde_json::json!({
+            "Mining": {
+                "Algorithm": "SHA-256"
+            },
+            "PerpetualTune": {
+                "Running": true,
+                "Algorithm": {
+                    "PowerTune": {
+                        "Target": 3000,
+                        "Throttle Target": 2600,
+                        "Error Throttle Target": 2800,
+                        "Unit": "W"
+                    }
+                }
+            }
+        });
+        let data = HashMap::from([(DataField::TuningTarget, summary)]);
+
+        assert_eq!(
+            miner.parse_scaled_tuning_target(&data),
+            Some(TuningTarget::Power(Power::from_watts(2600.0)))
+        );
     }
 
     #[test]

--- a/asic-rs-firmwares/epic/src/backends/v1/mod.rs
+++ b/asic-rs-firmwares/epic/src/backends/v1/mod.rs
@@ -1650,64 +1650,6 @@ mod tests {
     }
 
     #[test]
-    fn parse_scaled_tuning_target_uses_lower_throttle_target() {
-        let miner = PowerPlayV1::new(IpAddr::from([127, 0, 0, 1]), AntMinerModel::S19XP);
-        let summary = serde_json::json!({
-            "Mining": {
-                "Algorithm": "SHA-256"
-            },
-            "PerpetualTune": {
-                "Running": true,
-                "Algorithm": {
-                    "VoltageOptimizer": {
-                        "Target": 143,
-                        "Throttle Target": 120,
-                        "Error Throttle Target": 95,
-                        "Unit": "TH/s"
-                    }
-                }
-            }
-        });
-        let data = HashMap::from([(DataField::TuningTarget, summary)]);
-
-        assert_eq!(
-            miner.parse_scaled_tuning_target(&data),
-            Some(TuningTarget::HashRate(HashRate {
-                value: 95.0,
-                unit: HashRateUnit::TeraHash,
-                algo: "SHA-256".to_string(),
-            }))
-        );
-    }
-
-    #[test]
-    fn parse_scaled_tuning_target_uses_lower_power_throttle_target() {
-        let miner = PowerPlayV1::new(IpAddr::from([127, 0, 0, 1]), AntMinerModel::S19XP);
-        let summary = serde_json::json!({
-            "Mining": {
-                "Algorithm": "SHA-256"
-            },
-            "PerpetualTune": {
-                "Running": true,
-                "Algorithm": {
-                    "PowerTune": {
-                        "Target": 3000,
-                        "Throttle Target": 2600,
-                        "Error Throttle Target": 2800,
-                        "Unit": "W"
-                    }
-                }
-            }
-        });
-        let data = HashMap::from([(DataField::TuningTarget, summary)]);
-
-        assert_eq!(
-            miner.parse_scaled_tuning_target(&data),
-            Some(TuningTarget::Power(Power::from_watts(2600.0)))
-        );
-    }
-
-    #[test]
     fn parse_fan_config_test() -> anyhow::Result<()> {
         let summary = Value::from_str(SUMMARY)?;
         let fan_mode = summary

--- a/asic-rs-firmwares/epic/src/backends/v1/mod.rs
+++ b/asic-rs-firmwares/epic/src/backends/v1/mod.rs
@@ -1650,6 +1650,64 @@ mod tests {
     }
 
     #[test]
+    fn parse_scaled_tuning_target_uses_lower_throttle_target() {
+        let miner = PowerPlayV1::new(IpAddr::from([127, 0, 0, 1]), AntMinerModel::S19XP);
+        let summary = serde_json::json!({
+            "Mining": {
+                "Algorithm": "SHA-256"
+            },
+            "PerpetualTune": {
+                "Running": true,
+                "Algorithm": {
+                    "VoltageOptimizer": {
+                        "Target": 143,
+                        "Throttle Target": 120,
+                        "Error Throttle Target": 95,
+                        "Unit": "TH/s"
+                    }
+                }
+            }
+        });
+        let data = HashMap::from([(DataField::TuningTarget, summary)]);
+
+        assert_eq!(
+            miner.parse_scaled_tuning_target(&data),
+            Some(TuningTarget::HashRate(HashRate {
+                value: 95.0,
+                unit: HashRateUnit::TeraHash,
+                algo: "SHA-256".to_string(),
+            }))
+        );
+    }
+
+    #[test]
+    fn parse_scaled_tuning_target_uses_lower_power_throttle_target() {
+        let miner = PowerPlayV1::new(IpAddr::from([127, 0, 0, 1]), AntMinerModel::S19XP);
+        let summary = serde_json::json!({
+            "Mining": {
+                "Algorithm": "SHA-256"
+            },
+            "PerpetualTune": {
+                "Running": true,
+                "Algorithm": {
+                    "PowerTune": {
+                        "Target": 3000,
+                        "Throttle Target": 2600,
+                        "Error Throttle Target": 2800,
+                        "Unit": "W"
+                    }
+                }
+            }
+        });
+        let data = HashMap::from([(DataField::TuningTarget, summary)]);
+
+        assert_eq!(
+            miner.parse_scaled_tuning_target(&data),
+            Some(TuningTarget::Power(Power::from_watts(2600.0)))
+        );
+    }
+
+    #[test]
     fn parse_fan_config_test() -> anyhow::Result<()> {
         let summary = Value::from_str(SUMMARY)?;
         let fan_mode = summary

--- a/asic-rs-firmwares/luxminer/src/backends/v1/mod.rs
+++ b/asic-rs-firmwares/luxminer/src/backends/v1/mod.rs
@@ -983,6 +983,8 @@ impl GetTuningTarget for LuxMinerV1 {
     }
 }
 
+impl GetScaledTuningTarget for LuxMinerV1 {}
+
 impl GetPsuFans for LuxMinerV1 {}
 
 impl GetMessages for LuxMinerV1 {

--- a/asic-rs-firmwares/marathon/src/backends/v1/mod.rs
+++ b/asic-rs-firmwares/marathon/src/backends/v1/mod.rs
@@ -871,6 +871,8 @@ impl GetTuningTarget for MaraV1 {
     }
 }
 
+impl GetScaledTuningTarget for MaraV1 {}
+
 impl GetLightFlashing for MaraV1 {
     fn parse_light_flashing(&self, data: &HashMap<DataField, Value>) -> Option<bool> {
         data.extract::<bool>(DataField::LightFlashing)

--- a/asic-rs-firmwares/nerdaxe/src/backends/v1/mod.rs
+++ b/asic-rs-firmwares/nerdaxe/src/backends/v1/mod.rs
@@ -368,6 +368,7 @@ impl GetWattage for NerdAxeV1 {
     }
 }
 impl GetTuningTarget for NerdAxeV1 {}
+impl GetScaledTuningTarget for NerdAxeV1 {}
 impl GetLightFlashing for NerdAxeV1 {}
 impl GetMessages for NerdAxeV1 {
     fn parse_messages(&self, data: &HashMap<DataField, Value>) -> Vec<MinerMessage> {

--- a/asic-rs-firmwares/sealminer/src/backends/v2025/mod.rs
+++ b/asic-rs-firmwares/sealminer/src/backends/v2025/mod.rs
@@ -540,6 +540,8 @@ impl GetTuningTarget for SealMinerV2025 {
     }
 }
 
+impl GetScaledTuningTarget for SealMinerV2025 {}
+
 impl GetLightFlashing for SealMinerV2025 {
     fn parse_light_flashing(&self, data: &HashMap<DataField, Value>) -> Option<bool> {
         data.extract::<String>(DataField::LightFlashing)

--- a/asic-rs-firmwares/vnish/src/backends/v1_2_0/mod.rs
+++ b/asic-rs-firmwares/vnish/src/backends/v1_2_0/mod.rs
@@ -524,6 +524,8 @@ impl GetWattage for VnishV120 {
 
 impl GetTuningTarget for VnishV120 {}
 
+impl GetScaledTuningTarget for VnishV120 {}
+
 impl GetLightFlashing for VnishV120 {
     fn parse_light_flashing(&self, data: &HashMap<DataField, Value>) -> Option<bool> {
         data.extract::<bool>(DataField::LightFlashing)

--- a/asic-rs-firmwares/whatsminer/src/backends/v1/mod.rs
+++ b/asic-rs-firmwares/whatsminer/src/backends/v1/mod.rs
@@ -431,6 +431,7 @@ impl GetTuningTarget for WhatsMinerV1 {
             .map(TuningTarget::Power)
     }
 }
+impl GetScaledTuningTarget for WhatsMinerV1 {}
 impl GetLightFlashing for WhatsMinerV1 {}
 impl GetMessages for WhatsMinerV1 {
     fn parse_messages(&self, data: &HashMap<DataField, Value>) -> Vec<MinerMessage> {

--- a/asic-rs-firmwares/whatsminer/src/backends/v2/mod.rs
+++ b/asic-rs-firmwares/whatsminer/src/backends/v2/mod.rs
@@ -495,6 +495,7 @@ impl GetTuningTarget for WhatsMinerV2 {
         parse_v2_tuning(summary)
     }
 }
+impl GetScaledTuningTarget for WhatsMinerV2 {}
 impl GetLightFlashing for WhatsMinerV2 {
     fn parse_light_flashing(&self, data: &HashMap<DataField, Value>) -> Option<bool> {
         data.extract_map::<String, _>(DataField::LightFlashing, |l| l != "auto")

--- a/asic-rs-firmwares/whatsminer/src/backends/v3/mod.rs
+++ b/asic-rs-firmwares/whatsminer/src/backends/v3/mod.rs
@@ -524,6 +524,7 @@ impl GetTuningTarget for WhatsMinerV3 {
         parse_v3_tuning(tuning)
     }
 }
+impl GetScaledTuningTarget for WhatsMinerV3 {}
 impl GetLightFlashing for WhatsMinerV3 {
     fn parse_light_flashing(&self, data: &HashMap<DataField, Value>) -> Option<bool> {
         data.extract_map::<String, _>(DataField::LightFlashing, |l| l != "auto")

--- a/python/tests/test_pydantic_interop.py
+++ b/python/tests/test_pydantic_interop.py
@@ -110,6 +110,7 @@ def minimal_miner_data(**overrides: object) -> dict[str, object]:
         "fluid_temperature": None,
         "wattage": None,
         "tuning_target": None,
+        "scaled_tuning_target": None,
         "efficiency": None,
         "light_flashing": None,
         "messages": [],


### PR DESCRIPTION
## Summary
- add scaled tuning target to MinerData and miner backend requirements
- implement default empty scaled tuning target support for existing backends
- parse ePIC PowerPlay scaled tuning target from the lower of Throttle Target and Error Throttle Target

## Tests
- cargo test -p asic-rs-firmwares-epic
- cargo check