### PR TITLE
feat: parse control boards from data values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,6 +423,7 @@ dependencies = [
  "asic-rs-core",
  "pyo3",
  "serde",
+ "serde_json",
  "strum",
 ]
 

--- a/asic-rs-firmwares/epic/src/backends/v1/mod.rs
+++ b/asic-rs-firmwares/epic/src/backends/v1/mod.rs
@@ -347,14 +347,24 @@ impl GetDataLocations for PowerPlayV1 {
                     tag: None,
                 },
             )],
-            DataField::ControlBoardVersion => vec![(
-                WEB_CAPABILITIES,
-                DataExtractor {
-                    func: get_by_pointer,
-                    key: Some("/Control Board Version/cpuHardware"),
-                    tag: None,
-                },
-            )],
+            DataField::ControlBoardVersion => vec![
+                (
+                    WEB_CAPABILITIES,
+                    DataExtractor {
+                        func: get_by_pointer,
+                        key: Some("/Control Board Version/cpuHardware"),
+                        tag: Some("cpu"),
+                    },
+                ),
+                (
+                    WEB_CAPABILITIES,
+                    DataExtractor {
+                        func: get_by_pointer,
+                        key: Some("/Control Board Version/platform"),
+                        tag: Some("platform"),
+                    },
+                ),
+            ],
             DataField::SerialNumber => vec![(
                 WEB_CAPABILITIES,
                 DataExtractor {
@@ -463,7 +473,20 @@ impl GetControlBoardVersion for PowerPlayV1 {
         &self,
         data: &HashMap<DataField, Value>,
     ) -> Option<MinerControlBoard> {
-        let cb_type = data.extract::<String>(DataField::ControlBoardVersion)?;
+        if let Some(cb) =
+            data.extract_nested::<EPicControlBoard>(DataField::ControlBoardVersion, "platform")
+        {
+            return Some(cb.into());
+        }
+
+        if let Some(cb) =
+            data.extract_nested::<AntMinerControlBoard>(DataField::ControlBoardVersion, "platform")
+        {
+            return Some(cb.into());
+        }
+
+        // Fallback for older versions that do not have platform.
+        let cb_type = data.extract_nested::<String>(DataField::ControlBoardVersion, "cpu")?;
         match cb_type.as_str() {
             s if s.to_uppercase().contains("AMLOGIC") => {
                 Some(AntMinerControlBoard::AMLogic).map(|cb| cb.into())

--- a/asic-rs-makes/antminer/src/hardware.rs
+++ b/asic-rs-makes/antminer/src/hardware.rs
@@ -1,5 +1,7 @@
+use asic_rs_core::data::collector::FromValue;
 use asic_rs_core::data::{board::MinerControlBoard, device::MinerHardware};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use strum::Display;
 
 use crate::models::AntMinerModel;
@@ -318,6 +320,12 @@ impl AntMinerControlBoard {
             "ZYNQ7007" => Some(Self::Xilinx),
             _ => None,
         }
+    }
+}
+
+impl FromValue for AntMinerControlBoard {
+    fn from_value(value: &Value) -> Option<Self> {
+        Self::parse(value.as_str()?)
     }
 }
 

--- a/asic-rs-makes/auradine/src/hardware.rs
+++ b/asic-rs-makes/auradine/src/hardware.rs
@@ -1,4 +1,4 @@
-use asic_rs_core::data::{board::MinerControlBoard, device::MinerHardware};
+use asic_rs_core::data::{board::MinerControlBoard, collector::FromValue, device::MinerHardware};
 use serde::{Deserialize, Serialize};
 use strum::Display;
 
@@ -50,6 +50,12 @@ impl AuradineControlBoard {
             "T3" => Some(Self::T3),
             _ => None,
         }
+    }
+}
+
+impl FromValue for AuradineControlBoard {
+    fn from_value(value: &serde_json::Value) -> Option<Self> {
+        Self::parse(value.as_str()?)
     }
 }
 

--- a/asic-rs-makes/avalon/src/hardware.rs
+++ b/asic-rs-makes/avalon/src/hardware.rs
@@ -1,4 +1,4 @@
-use asic_rs_core::data::{board::MinerControlBoard, device::MinerHardware};
+use asic_rs_core::data::{board::MinerControlBoard, collector::FromValue, device::MinerHardware};
 use serde::{Deserialize, Serialize};
 use strum::Display;
 
@@ -124,6 +124,12 @@ impl AvalonMinerControlBoard {
             "MM4V1_X3" => Some(Self::MM4v1X3),
             _ => None,
         }
+    }
+}
+
+impl FromValue for AvalonMinerControlBoard {
+    fn from_value(value: &serde_json::Value) -> Option<Self> {
+        Self::parse(value.as_str()?)
     }
 }
 

--- a/asic-rs-makes/bitaxe/src/hardware.rs
+++ b/asic-rs-makes/bitaxe/src/hardware.rs
@@ -1,4 +1,4 @@
-use asic_rs_core::data::{board::MinerControlBoard, device::MinerHardware};
+use asic_rs_core::data::{board::MinerControlBoard, collector::FromValue, device::MinerHardware};
 use serde::{Deserialize, Serialize};
 use strum::Display;
 
@@ -65,6 +65,12 @@ impl BitaxeControlBoard {
             "800" => Some(Self::B800),
             _ => None,
         }
+    }
+}
+
+impl FromValue for BitaxeControlBoard {
+    fn from_value(value: &serde_json::Value) -> Option<Self> {
+        Self::parse(value.as_str()?)
     }
 }
 

--- a/asic-rs-makes/braiins/src/hardware.rs
+++ b/asic-rs-makes/braiins/src/hardware.rs
@@ -1,4 +1,4 @@
-use asic_rs_core::data::{board::MinerControlBoard, device::MinerHardware};
+use asic_rs_core::data::{board::MinerControlBoard, collector::FromValue, device::MinerHardware};
 use serde::{Deserialize, Serialize};
 use strum::Display;
 
@@ -35,6 +35,12 @@ impl BraiinsControlBoard {
             "BRAIINSCB" => Some(Self::BraiinsCB),
             _ => None,
         }
+    }
+}
+
+impl FromValue for BraiinsControlBoard {
+    fn from_value(value: &serde_json::Value) -> Option<Self> {
+        Self::parse(value.as_str()?)
     }
 }
 

--- a/asic-rs-makes/epic/src/hardware.rs
+++ b/asic-rs-makes/epic/src/hardware.rs
@@ -1,5 +1,7 @@
+use asic_rs_core::data::collector::FromValue;
 use asic_rs_core::data::{board::MinerControlBoard, device::MinerHardware};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use strum::Display;
 
 use crate::models::EPicModel;
@@ -31,9 +33,15 @@ impl EPicControlBoard {
     pub fn parse(s: &str) -> Option<Self> {
         let cb_model = s.trim().replace(' ', "").to_uppercase();
         match cb_model.as_ref() {
-            "EPICUMC" => Some(Self::EPicUMC),
+            "EPICUMC" | "UMC" => Some(Self::EPicUMC),
             _ => None,
         }
+    }
+}
+
+impl FromValue for EPicControlBoard {
+    fn from_value(value: &Value) -> Option<Self> {
+        Self::parse(value.as_str()?)
     }
 }
 

--- a/asic-rs-makes/marathon/Cargo.toml
+++ b/asic-rs-makes/marathon/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 asic-rs-core.workspace = true
 
 serde.workspace = true
+serde_json.workspace = true
 strum.workspace = true
 
 pyo3 = {workspace = true, optional = true}

--- a/asic-rs-makes/marathon/src/hardware.rs
+++ b/asic-rs-makes/marathon/src/hardware.rs
@@ -1,4 +1,4 @@
-use asic_rs_core::data::board::MinerControlBoard;
+use asic_rs_core::data::{board::MinerControlBoard, collector::FromValue};
 use serde::{Deserialize, Serialize};
 use strum::Display;
 
@@ -15,6 +15,12 @@ impl MarathonControlBoard {
             s if s.starts_with("MARACB") => Some(Self::MaraCB),
             _ => None,
         }
+    }
+}
+
+impl FromValue for MarathonControlBoard {
+    fn from_value(value: &serde_json::Value) -> Option<Self> {
+        Self::parse(value.as_str()?)
     }
 }
 

--- a/asic-rs-makes/nerdaxe/src/hardware.rs
+++ b/asic-rs-makes/nerdaxe/src/hardware.rs
@@ -1,4 +1,4 @@
-use asic_rs_core::data::{board::MinerControlBoard, device::MinerHardware};
+use asic_rs_core::data::{board::MinerControlBoard, collector::FromValue, device::MinerHardware};
 use serde::{Deserialize, Serialize};
 use strum::Display;
 
@@ -53,6 +53,12 @@ impl NerdAxeControlBoard {
             "800" => Some(Self::B800),
             _ => None,
         }
+    }
+}
+
+impl FromValue for NerdAxeControlBoard {
+    fn from_value(value: &serde_json::Value) -> Option<Self> {
+        Self::parse(value.as_str()?)
     }
 }
 

--- a/asic-rs-makes/sealminer/src/hardware.rs
+++ b/asic-rs-makes/sealminer/src/hardware.rs
@@ -1,4 +1,4 @@
-use asic_rs_core::data::{board::MinerControlBoard, device::MinerHardware};
+use asic_rs_core::data::{board::MinerControlBoard, collector::FromValue, device::MinerHardware};
 use serde::{Deserialize, Serialize};
 use strum::Display;
 
@@ -29,6 +29,12 @@ impl SealMinerControlBoard {
             s if s.starts_with("taurusair") => Some(Self::TaurusAir),
             _ => None,
         }
+    }
+}
+
+impl FromValue for SealMinerControlBoard {
+    fn from_value(value: &serde_json::Value) -> Option<Self> {
+        Self::parse(value.as_str()?)
     }
 }
 

--- a/asic-rs-makes/whatsminer/src/hardware.rs
+++ b/asic-rs-makes/whatsminer/src/hardware.rs
@@ -1,4 +1,4 @@
-use asic_rs_core::data::{board::MinerControlBoard, device::MinerHardware};
+use asic_rs_core::data::{board::MinerControlBoard, collector::FromValue, device::MinerHardware};
 use serde::{Deserialize, Serialize};
 use strum::Display;
 
@@ -2528,6 +2528,12 @@ impl WhatsMinerControlBoard {
             "H616" => Some(Self::H616),
             _ => None,
         }
+    }
+}
+
+impl FromValue for WhatsMinerControlBoard {
+    fn from_value(value: &serde_json::Value) -> Option<Self> {
+        Self::parse(value.as_str()?)
     }
 }
 


### PR DESCRIPTION
## Summary
- implement FromValue for make control board hardware enums
- allow ePIC PowerPlay control board parsing from platform data with existing CPU fallback
- add Marathon serde_json dependency needed for FromValue signature

## Tests
- cargo check
- cargo test -p asic-rs-makes-antminer -p asic-rs-makes-epic -p asic-rs-makes-sealminer -p asic-rs-makes-auradine -p asic-rs-makes-bitaxe -p asic-rs-makes-braiins -p asic-rs-makes-nerdaxe -p asic-rs-makes-avalon -p asic-rs-makes-marathon -p asic-rs-makes-whatsminer