### PR TITLE
feat: implement scaled tuning target for braiins

### DIFF
--- a/asic-rs-firmwares/braiins/src/backends/mod.rs
+++ b/asic-rs-firmwares/braiins/src/backends/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod util;
 pub mod v21_09;
 pub mod v25_03;
 pub mod v25_05;
@@ -10,6 +11,7 @@ use asic_rs_core::traits::{
     miner::{Miner, MinerConstructor},
     model::MinerModel,
 };
+
 use semver::Version;
 use v21_09::BraiinsV2109;
 use v25_03::BraiinsV2503;

--- a/asic-rs-firmwares/braiins/src/backends/util.rs
+++ b/asic-rs-firmwares/braiins/src/backends/util.rs
@@ -1,0 +1,43 @@
+use asic_rs_core::data::hashrate::{HashRate, HashRateUnit};
+use asic_rs_core::data::miner::TuningTarget;
+use measurements::Power;
+use serde_json::Value;
+
+pub(crate) fn parse_configured_tuning_target(value: &Value) -> Option<TuningTarget> {
+    parse_tagged_tuning_target(value, "configured")
+}
+
+pub(crate) fn parse_scaled_tuning_target(value: &Value) -> Option<TuningTarget> {
+    parse_tagged_tuning_target(value, "scaled")
+}
+
+fn parse_tagged_tuning_target(value: &Value, prefix: &str) -> Option<TuningTarget> {
+    let power_key = format!("{prefix}_power");
+    let hashrate_key = format!("{prefix}_hashrate");
+
+    let power = value
+        .get(&power_key)
+        .and_then(|v| v.as_f64().or_else(|| v.as_i64().map(|i| i as f64)))
+        .map(Power::from_watts)
+        .map(TuningTarget::Power);
+
+    let hashrate = value
+        .get(&hashrate_key)
+        .and_then(|v| v.as_f64().or_else(|| v.as_i64().map(|i| i as f64)))
+        .map(|value| {
+            TuningTarget::HashRate(HashRate {
+                value,
+                unit: HashRateUnit::TeraHash,
+                algo: "SHA256".to_string(),
+            })
+        });
+
+    match (
+        value.get("mode").and_then(Value::as_str),
+        value.get("mode").and_then(Value::as_i64),
+    ) {
+        (Some("HASHRATE_TARGET"), _) | (_, Some(2)) => hashrate.or(power),
+        (Some("POWER_TARGET"), _) | (_, Some(1)) => power.or(hashrate),
+        _ => power.or(hashrate),
+    }
+}

--- a/asic-rs-firmwares/braiins/src/backends/v21_09/mod.rs
+++ b/asic-rs-firmwares/braiins/src/backends/v21_09/mod.rs
@@ -27,6 +27,8 @@ use measurements::{AngularVelocity, Frequency, Power, Temperature, Voltage};
 use serde_json::{Value, json};
 use web::BraiinsWebAPI;
 
+use crate::backends::util::{parse_configured_tuning_target, parse_scaled_tuning_target};
+
 use crate::{
     backends::v21_09::{graphql::BraiinsGraphQLAPI, rpc::BraiinsRPCAPI},
     firmware::BraiinsFirmware,
@@ -119,6 +121,26 @@ impl GetDataLocations for BraiinsV2109 {
                                 hwDetails { chips frequencyMhz voltageV }
                                 temperatures { name degreesC }
                             }
+                        }
+                    }
+                }
+            }"#,
+        };
+        const GQL_TUNING: MinerCommand = MinerCommand::GraphQL {
+            command: r#"{
+                bosminer {
+                    config {
+                        ... on BosminerConfig {
+                            autotuning {
+                                mode
+                                powerTarget
+                                hashrateTarget
+                            }
+                        }
+                    }
+                    info {
+                        summary {
+                            power { limitW }
                         }
                     }
                 }
@@ -272,14 +294,40 @@ impl GetDataLocations for BraiinsV2109 {
                     tag: None,
                 },
             )],
-            DataField::TuningTarget => vec![(
-                GQL_SYSTEM,
-                DataExtractor {
-                    func: get_by_pointer,
-                    key: Some("/bosminer/info/summary/power/limitW"),
-                    tag: None,
-                },
-            )],
+            DataField::TuningTarget => vec![
+                (
+                    GQL_TUNING,
+                    DataExtractor {
+                        func: get_by_pointer,
+                        key: Some("/bosminer/config/autotuning/mode"),
+                        tag: Some("mode"),
+                    },
+                ),
+                (
+                    GQL_TUNING,
+                    DataExtractor {
+                        func: get_by_pointer,
+                        key: Some("/bosminer/config/autotuning/powerTarget"),
+                        tag: Some("configured_power"),
+                    },
+                ),
+                (
+                    GQL_TUNING,
+                    DataExtractor {
+                        func: get_by_pointer,
+                        key: Some("/bosminer/config/autotuning/hashrateTarget"),
+                        tag: Some("configured_hashrate"),
+                    },
+                ),
+                (
+                    GQL_TUNING,
+                    DataExtractor {
+                        func: get_by_pointer,
+                        key: Some("/bosminer/info/summary/power/limitW"),
+                        tag: Some("scaled_power"),
+                    },
+                ),
+            ],
             DataField::IsMining => vec![(
                 GQL_SYSTEM,
                 DataExtractor {
@@ -481,12 +529,17 @@ impl GetWattage for BraiinsV2109 {
 
 impl GetTuningTarget for BraiinsV2109 {
     fn parse_tuning_target(&self, data: &HashMap<DataField, Value>) -> Option<TuningTarget> {
-        data.extract_map::<f64, _>(DataField::TuningTarget, Power::from_watts)
-            .map(TuningTarget::Power)
+        data.get(&DataField::TuningTarget)
+            .and_then(parse_configured_tuning_target)
     }
 }
 
-impl GetScaledTuningTarget for BraiinsV2109 {}
+impl GetScaledTuningTarget for BraiinsV2109 {
+    fn parse_scaled_tuning_target(&self, data: &HashMap<DataField, Value>) -> Option<TuningTarget> {
+        data.get(&DataField::TuningTarget)
+            .and_then(parse_scaled_tuning_target)
+    }
+}
 
 impl GetLightFlashing for BraiinsV2109 {
     fn parse_light_flashing(&self, data: &HashMap<DataField, Value>) -> Option<bool> {
@@ -915,9 +968,13 @@ mod tests {
 
     use super::*;
     use crate::test::json::v21_09::{
-        GQL_BOARDS_COMMAND, GQL_POOLS_COMMAND, GQL_SYSTEM_COMMAND, VERSION_COMMAND,
-        WEB_NET_CONF_COMMAND,
+        GQL_BOARDS_COMMAND, GQL_POOLS_COMMAND, GQL_SYSTEM_COMMAND, GQL_TUNING_COMMAND,
+        VERSION_COMMAND, WEB_NET_CONF_COMMAND,
     };
+
+    fn gql(raw: &str) -> Value {
+        Value::from_str(raw).unwrap()["data"].clone()
+    }
 
     #[tokio::test]
     async fn test_braiins_os() {
@@ -994,6 +1051,26 @@ mod tests {
                 }
             }"#,
         };
+        let gql_tuning_command = MinerCommand::GraphQL {
+            command: r#"{
+                bosminer {
+                    config {
+                        ... on BosminerConfig {
+                            autotuning {
+                                mode
+                                powerTarget
+                                hashrateTarget
+                            }
+                        }
+                    }
+                    info {
+                        summary {
+                            power { limitW }
+                        }
+                    }
+                }
+            }"#,
+        };
         let rpc_version_command = MinerCommand::RPC {
             command: "version",
             parameters: None,
@@ -1003,18 +1080,10 @@ mod tests {
             parameters: None,
         };
 
-        results.insert(
-            gql_system_command,
-            Value::from_str(GQL_SYSTEM_COMMAND).unwrap(),
-        );
-        results.insert(
-            gql_boards_command,
-            Value::from_str(GQL_BOARDS_COMMAND).unwrap(),
-        );
-        results.insert(
-            gql_pools_command,
-            Value::from_str(GQL_POOLS_COMMAND).unwrap(),
-        );
+        results.insert(gql_system_command, gql(GQL_SYSTEM_COMMAND));
+        results.insert(gql_boards_command, gql(GQL_BOARDS_COMMAND));
+        results.insert(gql_pools_command, gql(GQL_POOLS_COMMAND));
+        results.insert(gql_tuning_command, gql(GQL_TUNING_COMMAND));
         results.insert(
             rpc_version_command,
             Value::from_str(VERSION_COMMAND).unwrap(),
@@ -1048,6 +1117,10 @@ mod tests {
         assert_eq!(miner_data.wattage, Some(Power::from_watts(735.0)));
         assert_eq!(
             miner_data.tuning_target,
+            Some(TuningTarget::Power(Power::from_watts(900.0)))
+        );
+        assert_eq!(
+            miner_data.scaled_tuning_target,
             Some(TuningTarget::Power(Power::from_watts(900.0)))
         );
         assert_eq!(

--- a/asic-rs-firmwares/braiins/src/backends/v25_03/mod.rs
+++ b/asic-rs-firmwares/braiins/src/backends/v25_03/mod.rs
@@ -1,7 +1,10 @@
 use std::{collections::HashMap, net::IpAddr, str::FromStr, time::Duration};
 
 use crate::{
-    backends::v21_09::{graphql::BraiinsGraphQLAPI, rpc::BraiinsRPCAPI, web::BraiinsWebAPI},
+    backends::{
+        util::{parse_configured_tuning_target, parse_scaled_tuning_target},
+        v21_09::{graphql::BraiinsGraphQLAPI, rpc::BraiinsRPCAPI, web::BraiinsWebAPI},
+    },
     firmware::BraiinsFirmware,
 };
 use anyhow;
@@ -113,6 +116,26 @@ impl GetDataLocations for BraiinsV2503 {
                                 hwDetails { chips frequencyMhz voltageV hbSerialNumber }
                                 temperatures { name degreesC }
                             }
+                        }
+                    }
+                }
+            }"#,
+        };
+        const GQL_TUNING: MinerCommand = MinerCommand::GraphQL {
+            command: r#"{
+                bosminer {
+                    config {
+                        ... on BosminerConfig {
+                            autotuning {
+                                mode
+                                powerTarget
+                                hashrateTarget
+                            }
+                        }
+                    }
+                    info {
+                        summary {
+                            power { limitW }
                         }
                     }
                 }
@@ -266,14 +289,40 @@ impl GetDataLocations for BraiinsV2503 {
                     tag: None,
                 },
             )],
-            DataField::TuningTarget => vec![(
-                GQL_SYSTEM,
-                DataExtractor {
-                    func: get_by_pointer,
-                    key: Some("/bosminer/info/summary/power/limitW"),
-                    tag: None,
-                },
-            )],
+            DataField::TuningTarget => vec![
+                (
+                    GQL_TUNING,
+                    DataExtractor {
+                        func: get_by_pointer,
+                        key: Some("/bosminer/config/autotuning/mode"),
+                        tag: Some("mode"),
+                    },
+                ),
+                (
+                    GQL_TUNING,
+                    DataExtractor {
+                        func: get_by_pointer,
+                        key: Some("/bosminer/config/autotuning/powerTarget"),
+                        tag: Some("configured_power"),
+                    },
+                ),
+                (
+                    GQL_TUNING,
+                    DataExtractor {
+                        func: get_by_pointer,
+                        key: Some("/bosminer/config/autotuning/hashrateTarget"),
+                        tag: Some("configured_hashrate"),
+                    },
+                ),
+                (
+                    GQL_TUNING,
+                    DataExtractor {
+                        func: get_by_pointer,
+                        key: Some("/bosminer/info/summary/power/limitW"),
+                        tag: Some("scaled_power"),
+                    },
+                ),
+            ],
             DataField::IsMining => vec![(
                 GQL_SYSTEM,
                 DataExtractor {
@@ -479,12 +528,17 @@ impl GetWattage for BraiinsV2503 {
 
 impl GetTuningTarget for BraiinsV2503 {
     fn parse_tuning_target(&self, data: &HashMap<DataField, Value>) -> Option<TuningTarget> {
-        data.extract_map::<f64, _>(DataField::TuningTarget, Power::from_watts)
-            .map(TuningTarget::Power)
+        data.get(&DataField::TuningTarget)
+            .and_then(parse_configured_tuning_target)
     }
 }
 
-impl GetScaledTuningTarget for BraiinsV2503 {}
+impl GetScaledTuningTarget for BraiinsV2503 {
+    fn parse_scaled_tuning_target(&self, data: &HashMap<DataField, Value>) -> Option<TuningTarget> {
+        data.get(&DataField::TuningTarget)
+            .and_then(parse_scaled_tuning_target)
+    }
+}
 
 impl GetLightFlashing for BraiinsV2503 {
     fn parse_light_flashing(&self, data: &HashMap<DataField, Value>) -> Option<bool> {
@@ -910,16 +964,15 @@ impl SupportsFanConfig for BraiinsV2503 {
 mod tests {
     use std::str::FromStr;
 
+    use super::*;
+    use crate::test::json::v25_03::{
+        GQL_BOARDS_COMMAND, GQL_EVENTS_COMMAND, GQL_POOLS_COMMAND, GQL_SYSTEM_COMMAND,
+        GQL_TUNING_COMMAND, VERSION_COMMAND, WEB_NET_CONF_COMMAND,
+    };
     use asic_rs_core::{data::collector::DataCollector, test::api::MockAPIClient};
     use asic_rs_makes_antminer::models::AntMinerModel;
     use macaddr::MacAddr;
     use measurements::Power;
-
-    use super::*;
-    use crate::test::json::v25_03::{
-        GQL_BOARDS_COMMAND, GQL_EVENTS_COMMAND, GQL_POOLS_COMMAND, GQL_SYSTEM_COMMAND,
-        VERSION_COMMAND, WEB_NET_CONF_COMMAND,
-    };
 
     /// GQL responses from real miners include a "data" wrapper that the real
     /// GraphQL client strips before returning. Strip it here to match.
@@ -932,9 +985,8 @@ mod tests {
         let miner = BraiinsV2503::new(IpAddr::from([127, 0, 0, 1]), AntMinerModel::S21Plus);
 
         let mut results = HashMap::new();
-        results.insert(
-            MinerCommand::GraphQL {
-                command: r#"{
+        let gql_system_command = MinerCommand::GraphQL {
+            command: r#"{
                 bos {
                     hostname
                     faultLight
@@ -954,12 +1006,9 @@ mod tests {
                     }
                 }
             }"#,
-            },
-            gql(GQL_SYSTEM_COMMAND),
-        );
-        results.insert(
-            MinerCommand::GraphQL {
-                command: r#"{
+        };
+        let gql_boards_command = MinerCommand::GraphQL {
+            command: r#"{
                 bosminer {
                     info {
                         workSolver {
@@ -967,19 +1016,16 @@ mod tests {
                                 name
                                 realHashrate { mhs5S }
                                 nominalMhs
-                                hwDetails { chips frequencyMhz voltageV hbSerialNumber }
+                                hwDetails { chips frequencyMhz voltageV }
                                 temperatures { name degreesC }
                             }
                         }
                     }
                 }
             }"#,
-            },
-            gql(GQL_BOARDS_COMMAND),
-        );
-        results.insert(
-            MinerCommand::GraphQL {
-                command: r#"{
+        };
+        let gql_pools_command = MinerCommand::GraphQL {
+            command: r#"{
                 bosminer {
                     config {
                         ... on BosminerConfig {
@@ -1007,30 +1053,59 @@ mod tests {
                     }
                 }
             }"#,
-            },
-            gql(GQL_POOLS_COMMAND),
-        );
+        };
+        let gql_tuning_command = MinerCommand::GraphQL {
+            command: r#"{
+                bosminer {
+                    config {
+                        ... on BosminerConfig {
+                            autotuning {
+                                mode
+                                powerTarget
+                                hashrateTarget
+                            }
+                        }
+                    }
+                    info {
+                        summary {
+                            power { limitW }
+                        }
+                    }
+                }
+            }"#,
+        };
+        let gql_events_command = MinerCommand::GraphQL {
+            command: r#"{
+                events {
+                    appeals {
+                        id
+                        kind
+                        message
+                        timestamp
+                    }
+                }
+            }"#,
+        };
+        let rpc_version_command = MinerCommand::RPC {
+            command: "version",
+            parameters: None,
+        };
+        let web_net_conf_command = MinerCommand::WebAPI {
+            command: "admin/network/iface_status/lan",
+            parameters: None,
+        };
+
+        results.insert(gql_system_command, gql(GQL_SYSTEM_COMMAND));
+        results.insert(gql_boards_command, gql(GQL_BOARDS_COMMAND));
+        results.insert(gql_pools_command, gql(GQL_POOLS_COMMAND));
+        results.insert(gql_tuning_command, gql(GQL_TUNING_COMMAND));
+        results.insert(gql_events_command, gql(GQL_EVENTS_COMMAND));
         results.insert(
-            miner
-                .get_locations(DataField::Messages)
-                .into_iter()
-                .next()
-                .unwrap()
-                .0,
-            gql(GQL_EVENTS_COMMAND),
-        );
-        results.insert(
-            MinerCommand::RPC {
-                command: "version",
-                parameters: None,
-            },
+            rpc_version_command,
             Value::from_str(VERSION_COMMAND).unwrap(),
         );
         results.insert(
-            MinerCommand::WebAPI {
-                command: "admin/network/iface_status/lan",
-                parameters: None,
-            },
+            web_net_conf_command,
             Value::from_str(WEB_NET_CONF_COMMAND).unwrap(),
         );
 
@@ -1055,6 +1130,10 @@ mod tests {
         assert_eq!(miner_data.wattage, Some(Power::from_watts(4448.0)));
         assert_eq!(
             miner_data.tuning_target,
+            Some(TuningTarget::Power(Power::from_watts(3878.0)))
+        );
+        assert_eq!(
+            miner_data.scaled_tuning_target,
             Some(TuningTarget::Power(Power::from_watts(3878.0)))
         );
         assert_eq!(miner_data.pools.len(), 1);

--- a/asic-rs-firmwares/braiins/src/backends/v25_05/mod.rs
+++ b/asic-rs-firmwares/braiins/src/backends/v25_05/mod.rs
@@ -27,7 +27,10 @@ use measurements::{AngularVelocity, Frequency, Power, Temperature, Voltage};
 use serde_json::{Value, json};
 
 use crate::{
-    backends::v21_09::{graphql::BraiinsGraphQLAPI, rpc::BraiinsRPCAPI, web::BraiinsWebAPI},
+    backends::{
+        util::{parse_configured_tuning_target, parse_scaled_tuning_target},
+        v21_09::{graphql::BraiinsGraphQLAPI, rpc::BraiinsRPCAPI, web::BraiinsWebAPI},
+    },
     firmware::BraiinsFirmware,
 };
 
@@ -114,6 +117,26 @@ impl GetDataLocations for BraiinsV2505 {
                                 hwDetails { chips frequencyMhz voltageV hbSerialNumber }
                                 temperatures { name degreesC }
                             }
+                        }
+                    }
+                }
+            }"#,
+        };
+        const GQL_TUNING: MinerCommand = MinerCommand::GraphQL {
+            command: r#"{
+                bosminer {
+                    config {
+                        ... on BosminerConfig {
+                            autotuning {
+                                mode
+                                powerTarget
+                                hashrateTarget
+                            }
+                        }
+                    }
+                    info {
+                        summary {
+                            power { limitW }
                         }
                     }
                 }
@@ -267,14 +290,40 @@ impl GetDataLocations for BraiinsV2505 {
                     tag: None,
                 },
             )],
-            DataField::TuningTarget => vec![(
-                GQL_SYSTEM,
-                DataExtractor {
-                    func: get_by_pointer,
-                    key: Some("/bosminer/info/summary/power/limitW"),
-                    tag: None,
-                },
-            )],
+            DataField::TuningTarget => vec![
+                (
+                    GQL_TUNING,
+                    DataExtractor {
+                        func: get_by_pointer,
+                        key: Some("/bosminer/config/autotuning/mode"),
+                        tag: Some("mode"),
+                    },
+                ),
+                (
+                    GQL_TUNING,
+                    DataExtractor {
+                        func: get_by_pointer,
+                        key: Some("/bosminer/config/autotuning/powerTarget"),
+                        tag: Some("configured_power"),
+                    },
+                ),
+                (
+                    GQL_TUNING,
+                    DataExtractor {
+                        func: get_by_pointer,
+                        key: Some("/bosminer/config/autotuning/hashrateTarget"),
+                        tag: Some("configured_hashrate"),
+                    },
+                ),
+                (
+                    GQL_TUNING,
+                    DataExtractor {
+                        func: get_by_pointer,
+                        key: Some("/bosminer/info/summary/power/limitW"),
+                        tag: Some("scaled_power"),
+                    },
+                ),
+            ],
             DataField::IsMining => vec![(
                 GQL_SYSTEM,
                 DataExtractor {
@@ -485,12 +534,17 @@ impl GetWattage for BraiinsV2505 {
 
 impl GetTuningTarget for BraiinsV2505 {
     fn parse_tuning_target(&self, data: &HashMap<DataField, Value>) -> Option<TuningTarget> {
-        data.extract_map::<f64, _>(DataField::TuningTarget, Power::from_watts)
-            .map(TuningTarget::Power)
+        data.get(&DataField::TuningTarget)
+            .and_then(parse_configured_tuning_target)
     }
 }
 
-impl GetScaledTuningTarget for BraiinsV2505 {}
+impl GetScaledTuningTarget for BraiinsV2505 {
+    fn parse_scaled_tuning_target(&self, data: &HashMap<DataField, Value>) -> Option<TuningTarget> {
+        data.get(&DataField::TuningTarget)
+            .and_then(parse_scaled_tuning_target)
+    }
+}
 
 impl GetLightFlashing for BraiinsV2505 {
     fn parse_light_flashing(&self, data: &HashMap<DataField, Value>) -> Option<bool> {
@@ -915,16 +969,15 @@ impl SupportsFanConfig for BraiinsV2505 {
 mod tests {
     use std::str::FromStr;
 
+    use super::*;
+    use crate::test::json::v25_05::{
+        GQL_BOARDS_COMMAND, GQL_EVENTS_COMMAND, GQL_POOLS_COMMAND, GQL_SYSTEM_COMMAND,
+        GQL_TUNING_COMMAND, VERSION_COMMAND, WEB_NET_CONF_COMMAND,
+    };
     use asic_rs_core::{data::collector::DataCollector, test::api::MockAPIClient};
     use asic_rs_makes_antminer::models::AntMinerModel;
     use macaddr::MacAddr;
     use measurements::Power;
-
-    use super::*;
-    use crate::test::json::v25_05::{
-        GQL_BOARDS_COMMAND, GQL_EVENTS_COMMAND, GQL_POOLS_COMMAND, GQL_SYSTEM_COMMAND,
-        VERSION_COMMAND, WEB_NET_CONF_COMMAND,
-    };
 
     /// GQL responses from real miners include a "data" wrapper that the real
     /// GraphQL client strips before returning. Strip it here to match.
@@ -937,9 +990,8 @@ mod tests {
         let miner = BraiinsV2505::new(IpAddr::from([127, 0, 0, 1]), AntMinerModel::S21Plus);
 
         let mut results = HashMap::new();
-        results.insert(
-            MinerCommand::GraphQL {
-                command: r#"{
+        let gql_system_command = MinerCommand::GraphQL {
+            command: r#"{
                 bos {
                     hostname
                     faultLight
@@ -959,12 +1011,9 @@ mod tests {
                     }
                 }
             }"#,
-            },
-            gql(GQL_SYSTEM_COMMAND),
-        );
-        results.insert(
-            MinerCommand::GraphQL {
-                command: r#"{
+        };
+        let gql_boards_command = MinerCommand::GraphQL {
+            command: r#"{
                 bosminer {
                     info {
                         workSolver {
@@ -972,19 +1021,16 @@ mod tests {
                                 name
                                 realHashrate { mhs5S }
                                 nominalMhs
-                                hwDetails { chips frequencyMhz voltageV hbSerialNumber }
+                                hwDetails { chips frequencyMhz voltageV }
                                 temperatures { name degreesC }
                             }
                         }
                     }
                 }
             }"#,
-            },
-            gql(GQL_BOARDS_COMMAND),
-        );
-        results.insert(
-            MinerCommand::GraphQL {
-                command: r#"{
+        };
+        let gql_pools_command = MinerCommand::GraphQL {
+            command: r#"{
                 bosminer {
                     config {
                         ... on BosminerConfig {
@@ -1012,30 +1058,59 @@ mod tests {
                     }
                 }
             }"#,
-            },
-            gql(GQL_POOLS_COMMAND),
-        );
+        };
+        let gql_tuning_command = MinerCommand::GraphQL {
+            command: r#"{
+                bosminer {
+                    config {
+                        ... on BosminerConfig {
+                            autotuning {
+                                mode
+                                powerTarget
+                                hashrateTarget
+                            }
+                        }
+                    }
+                    info {
+                        summary {
+                            power { limitW }
+                        }
+                    }
+                }
+            }"#,
+        };
+        let gql_events_command = MinerCommand::GraphQL {
+            command: r#"{
+                events {
+                    appeals {
+                        id
+                        kind
+                        message
+                        timestamp
+                    }
+                }
+            }"#,
+        };
+        let rpc_version_command = MinerCommand::RPC {
+            command: "version",
+            parameters: None,
+        };
+        let web_net_conf_command = MinerCommand::WebAPI {
+            command: "admin/network/iface_status/lan",
+            parameters: None,
+        };
+
+        results.insert(gql_system_command, gql(GQL_SYSTEM_COMMAND));
+        results.insert(gql_boards_command, gql(GQL_BOARDS_COMMAND));
+        results.insert(gql_pools_command, gql(GQL_POOLS_COMMAND));
+        results.insert(gql_tuning_command, gql(GQL_TUNING_COMMAND));
+        results.insert(gql_events_command, gql(GQL_EVENTS_COMMAND));
         results.insert(
-            miner
-                .get_locations(DataField::Messages)
-                .into_iter()
-                .next()
-                .unwrap()
-                .0,
-            gql(GQL_EVENTS_COMMAND),
-        );
-        results.insert(
-            MinerCommand::RPC {
-                command: "version",
-                parameters: None,
-            },
+            rpc_version_command,
             Value::from_str(VERSION_COMMAND).unwrap(),
         );
         results.insert(
-            MinerCommand::WebAPI {
-                command: "admin/network/iface_status/lan",
-                parameters: None,
-            },
+            web_net_conf_command,
             Value::from_str(WEB_NET_CONF_COMMAND).unwrap(),
         );
 
@@ -1060,6 +1135,10 @@ mod tests {
         assert_eq!(miner_data.wattage, Some(Power::from_watts(3698.0)));
         assert_eq!(
             miner_data.tuning_target,
+            Some(TuningTarget::Power(Power::from_watts(3878.0)))
+        );
+        assert_eq!(
+            miner_data.scaled_tuning_target,
             Some(TuningTarget::Power(Power::from_watts(3878.0)))
         );
         assert_eq!(miner_data.pools.len(), 1);

--- a/asic-rs-firmwares/braiins/src/backends/v25_07/mod.rs
+++ b/asic-rs-firmwares/braiins/src/backends/v25_07/mod.rs
@@ -30,7 +30,13 @@ use reqwest::Method;
 use serde_json::{Value, json};
 use web::BraiinsWebAPI;
 
-use crate::{backends::v21_09::graphql::BraiinsGraphQLAPI, firmware::BraiinsFirmware};
+use crate::{
+    backends::{
+        util::{parse_configured_tuning_target, parse_scaled_tuning_target},
+        v21_09::graphql::BraiinsGraphQLAPI,
+    },
+    firmware::BraiinsFirmware,
+};
 
 pub mod web;
 
@@ -102,6 +108,10 @@ impl GetDataLocations for BraiinsV2507 {
         };
         const WEB_PERFORMANCE_TUNER_STATE: MinerCommand = MinerCommand::WebAPI {
             command: "performance/tuner-state",
+            parameters: None,
+        };
+        const WEB_MINER_CONFIGURATION: MinerCommand = MinerCommand::WebAPI {
+            command: "configuration/miner",
             parameters: None,
         };
         const WEB_POOLS: MinerCommand = MinerCommand::WebAPI {
@@ -242,14 +252,50 @@ impl GetDataLocations for BraiinsV2507 {
                     tag: None,
                 },
             )],
-            DataField::TuningTarget => vec![(
-                WEB_PERFORMANCE_TUNER_STATE,
-                DataExtractor {
-                    func: get_by_pointer,
-                    key: Some("/mode_state/powertargetmodestate/current_target/watt"),
-                    tag: None,
-                },
-            )],
+            DataField::TuningTarget => vec![
+                (
+                    WEB_MINER_CONFIGURATION,
+                    DataExtractor {
+                        func: get_by_pointer,
+                        key: Some("/tuner/tuner_mode"),
+                        tag: Some("mode"),
+                    },
+                ),
+                (
+                    WEB_MINER_CONFIGURATION,
+                    DataExtractor {
+                        func: get_by_pointer,
+                        key: Some("/tuner/power_target/watt"),
+                        tag: Some("configured_power"),
+                    },
+                ),
+                (
+                    WEB_MINER_CONFIGURATION,
+                    DataExtractor {
+                        func: get_by_pointer,
+                        key: Some("/tuner/hashrate_target/terahash_per_second"),
+                        tag: Some("configured_hashrate"),
+                    },
+                ),
+                (
+                    WEB_PERFORMANCE_TUNER_STATE,
+                    DataExtractor {
+                        func: get_by_pointer,
+                        key: Some("/mode_state/powertargetmodestate/current_target/watt"),
+                        tag: Some("scaled_power"),
+                    },
+                ),
+                (
+                    WEB_PERFORMANCE_TUNER_STATE,
+                    DataExtractor {
+                        func: get_by_pointer,
+                        key: Some(
+                            "/mode_state/hashratetargetmodestate/current_target/terahash_per_second",
+                        ),
+                        tag: Some("scaled_hashrate"),
+                    },
+                ),
+            ],
             DataField::SerialNumber => vec![(
                 WEB_MINER_DETAILS,
                 DataExtractor {
@@ -551,12 +597,17 @@ impl GetWattage for BraiinsV2507 {
 
 impl GetTuningTarget for BraiinsV2507 {
     fn parse_tuning_target(&self, data: &HashMap<DataField, Value>) -> Option<TuningTarget> {
-        data.extract_map::<i64, _>(DataField::TuningTarget, |w| Power::from_watts(w as f64))
-            .map(TuningTarget::Power)
+        data.get(&DataField::TuningTarget)
+            .and_then(parse_configured_tuning_target)
     }
 }
 
-impl GetScaledTuningTarget for BraiinsV2507 {}
+impl GetScaledTuningTarget for BraiinsV2507 {
+    fn parse_scaled_tuning_target(&self, data: &HashMap<DataField, Value>) -> Option<TuningTarget> {
+        data.get(&DataField::TuningTarget)
+            .and_then(parse_scaled_tuning_target)
+    }
+}
 
 impl GetFluidTemperature for BraiinsV2507 {}
 
@@ -806,17 +857,17 @@ mod tests {
     use super::*;
     use crate::test::json::v25_07::{
         WEB_COOLING_STATE_COMMAND as V07_COOLING, WEB_HASHBOARDS_COMMAND as V07_BOARDS,
-        WEB_LOCATE_COMMAND as V07_LOCATE, WEB_MINER_DETAILS_COMMAND as V07_DETAILS,
-        WEB_MINER_STATS_COMMAND as V07_STATS, WEB_NETWORK_COMMAND as V07_NETWORK,
-        WEB_PERFORMANCE_TUNER_STATE_COMMAND as V07_TUNER, WEB_POOLS_COMMAND as V07_POOLS,
-        WEB_VERSION_COMMAND as V07_VERSION,
+        WEB_LOCATE_COMMAND as V07_LOCATE, WEB_MINER_CONFIGURATION_COMMAND as V07_CONFIG,
+        WEB_MINER_DETAILS_COMMAND as V07_DETAILS, WEB_MINER_STATS_COMMAND as V07_STATS,
+        WEB_NETWORK_COMMAND as V07_NETWORK, WEB_PERFORMANCE_TUNER_STATE_COMMAND as V07_TUNER,
+        WEB_POOLS_COMMAND as V07_POOLS, WEB_VERSION_COMMAND as V07_VERSION,
     };
     use crate::test::json::v25_11::{
         WEB_COOLING_STATE_COMMAND as V11_COOLING, WEB_HASHBOARDS_COMMAND as V11_BOARDS,
-        WEB_LOCATE_COMMAND as V11_LOCATE, WEB_MINER_DETAILS_COMMAND as V11_DETAILS,
-        WEB_MINER_STATS_COMMAND as V11_STATS, WEB_NETWORK_COMMAND as V11_NETWORK,
-        WEB_PERFORMANCE_TUNER_STATE_COMMAND as V11_TUNER, WEB_POOLS_COMMAND as V11_POOLS,
-        WEB_VERSION_COMMAND as V11_VERSION,
+        WEB_LOCATE_COMMAND as V11_LOCATE, WEB_MINER_CONFIGURATION_COMMAND as V11_CONFIG,
+        WEB_MINER_DETAILS_COMMAND as V11_DETAILS, WEB_MINER_STATS_COMMAND as V11_STATS,
+        WEB_NETWORK_COMMAND as V11_NETWORK, WEB_PERFORMANCE_TUNER_STATE_COMMAND as V11_TUNER,
+        WEB_POOLS_COMMAND as V11_POOLS, WEB_VERSION_COMMAND as V11_VERSION,
     };
 
     #[tokio::test]
@@ -858,6 +909,13 @@ mod tests {
                 parameters: None,
             },
             Value::from_str(V07_TUNER).unwrap(),
+        );
+        results.insert(
+            MinerCommand::WebAPI {
+                command: "configuration/miner",
+                parameters: None,
+            },
+            Value::from_str(V07_CONFIG).unwrap(),
         );
         results.insert(
             miner
@@ -922,6 +980,10 @@ mod tests {
             miner_data.tuning_target,
             Some(TuningTarget::Power(Power::from_watts(3031.0)))
         );
+        assert_eq!(
+            miner_data.scaled_tuning_target,
+            Some(TuningTarget::Power(Power::from_watts(3031.0)))
+        );
         assert_eq!(miner_data.pools.len(), 1);
         assert_eq!(miner_data.pools[0].len(), 2);
         assert!(miner_data.hashrate.is_some());
@@ -967,6 +1029,13 @@ mod tests {
                 parameters: None,
             },
             Value::from_str(V11_TUNER).unwrap(),
+        );
+        results.insert(
+            MinerCommand::WebAPI {
+                command: "configuration/miner",
+                parameters: None,
+            },
+            Value::from_str(V11_CONFIG).unwrap(),
         );
         results.insert(
             miner
@@ -1032,11 +1101,49 @@ mod tests {
         assert_eq!(miner_data.wattage, Some(Power::from_watts(2472.0)));
         assert_eq!(
             miner_data.tuning_target,
+            Some(TuningTarget::Power(Power::from_watts(3031.0)))
+        );
+        assert_eq!(
+            miner_data.scaled_tuning_target,
             Some(TuningTarget::Power(Power::from_watts(2431.0)))
         );
         assert_eq!(miner_data.pools.len(), 1);
         assert_eq!(miner_data.pools[0].len(), 2);
         assert!(miner_data.hashrate.is_some());
         assert!(miner_data.expected_hashrate.is_some());
+    }
+
+    #[test]
+    fn test_braiins_v25_07_tuner_mode_selects_hashrate_targets() {
+        let miner = BraiinsV2507::new(IpAddr::from([127, 0, 0, 1]), AntMinerModel::S19XP);
+        let mut data = HashMap::new();
+
+        data.insert(
+            DataField::TuningTarget,
+            json!({
+                "mode": 2,
+                "configured_power": 3031.0,
+                "configured_hashrate": 120.5,
+                "scaled_power": 2431.0,
+                "scaled_hashrate": 118.25,
+            }),
+        );
+
+        assert_eq!(
+            miner.parse_tuning_target(&data),
+            Some(TuningTarget::HashRate(HashRate {
+                value: 120.5,
+                unit: HashRateUnit::TeraHash,
+                algo: "SHA256".to_string(),
+            }))
+        );
+        assert_eq!(
+            miner.parse_scaled_tuning_target(&data),
+            Some(TuningTarget::HashRate(HashRate {
+                value: 118.25,
+                unit: HashRateUnit::TeraHash,
+                algo: "SHA256".to_string(),
+            }))
+        );
     }
 }

--- a/asic-rs-firmwares/braiins/src/backends/v26_04/mod.rs
+++ b/asic-rs-firmwares/braiins/src/backends/v26_04/mod.rs
@@ -31,7 +31,13 @@ use serde_json::{Value, json};
 
 use web::BraiinsWebAPI;
 
-use crate::{backends::v21_09::graphql::BraiinsGraphQLAPI, firmware::BraiinsFirmware};
+use crate::{
+    backends::{
+        util::{parse_configured_tuning_target, parse_scaled_tuning_target},
+        v21_09::graphql::BraiinsGraphQLAPI,
+    },
+    firmware::BraiinsFirmware,
+};
 
 pub mod web;
 
@@ -103,6 +109,10 @@ impl GetDataLocations for BraiinsV2604 {
         };
         const WEB_PERFORMANCE_TUNER_STATE: MinerCommand = MinerCommand::WebAPI {
             command: "performance/tuner-state",
+            parameters: None,
+        };
+        const WEB_MINER_CONFIGURATION: MinerCommand = MinerCommand::WebAPI {
+            command: "configuration/miner",
             parameters: None,
         };
         const WEB_POOLS: MinerCommand = MinerCommand::WebAPI {
@@ -243,14 +253,50 @@ impl GetDataLocations for BraiinsV2604 {
                     tag: None,
                 },
             )],
-            DataField::TuningTarget => vec![(
-                WEB_PERFORMANCE_TUNER_STATE,
-                DataExtractor {
-                    func: get_by_pointer,
-                    key: Some("/mode_state/powertargetmodestate/current_target/watt"),
-                    tag: None,
-                },
-            )],
+            DataField::TuningTarget => vec![
+                (
+                    WEB_MINER_CONFIGURATION,
+                    DataExtractor {
+                        func: get_by_pointer,
+                        key: Some("/tuner/tuner_mode"),
+                        tag: Some("mode"),
+                    },
+                ),
+                (
+                    WEB_MINER_CONFIGURATION,
+                    DataExtractor {
+                        func: get_by_pointer,
+                        key: Some("/tuner/power_target/watt"),
+                        tag: Some("configured_power"),
+                    },
+                ),
+                (
+                    WEB_MINER_CONFIGURATION,
+                    DataExtractor {
+                        func: get_by_pointer,
+                        key: Some("/tuner/hashrate_target/terahash_per_second"),
+                        tag: Some("configured_hashrate"),
+                    },
+                ),
+                (
+                    WEB_PERFORMANCE_TUNER_STATE,
+                    DataExtractor {
+                        func: get_by_pointer,
+                        key: Some("/mode_state/powertargetmodestate/current_target/watt"),
+                        tag: Some("scaled_power"),
+                    },
+                ),
+                (
+                    WEB_PERFORMANCE_TUNER_STATE,
+                    DataExtractor {
+                        func: get_by_pointer,
+                        key: Some(
+                            "/mode_state/hashratetargetmodestate/current_target/terahash_per_second",
+                        ),
+                        tag: Some("scaled_hashrate"),
+                    },
+                ),
+            ],
             DataField::SerialNumber => vec![(
                 WEB_MINER_DETAILS,
                 DataExtractor {
@@ -547,12 +593,17 @@ impl GetWattage for BraiinsV2604 {
 
 impl GetTuningTarget for BraiinsV2604 {
     fn parse_tuning_target(&self, data: &HashMap<DataField, Value>) -> Option<TuningTarget> {
-        data.extract_map::<i64, _>(DataField::TuningTarget, |w| Power::from_watts(w as f64))
-            .map(TuningTarget::Power)
+        data.get(&DataField::TuningTarget)
+            .and_then(parse_configured_tuning_target)
     }
 }
 
-impl GetScaledTuningTarget for BraiinsV2604 {}
+impl GetScaledTuningTarget for BraiinsV2604 {
+    fn parse_scaled_tuning_target(&self, data: &HashMap<DataField, Value>) -> Option<TuningTarget> {
+        data.get(&DataField::TuningTarget)
+            .and_then(parse_scaled_tuning_target)
+    }
+}
 
 impl GetFluidTemperature for BraiinsV2604 {}
 
@@ -821,8 +872,9 @@ mod tests {
     use super::*;
     use crate::test::json::v26_04::{
         WEB_COOLING_STATE_COMMAND, WEB_HASHBOARDS_COMMAND, WEB_LOCATE_COMMAND,
-        WEB_MINER_DETAILS_COMMAND, WEB_MINER_STATS_COMMAND, WEB_NETWORK_COMMAND,
-        WEB_PERFORMANCE_TUNER_STATE_COMMAND, WEB_POOLS_COMMAND, WEB_VERSION_COMMAND,
+        WEB_MINER_CONFIGURATION_COMMAND, WEB_MINER_DETAILS_COMMAND, WEB_MINER_STATS_COMMAND,
+        WEB_NETWORK_COMMAND, WEB_PERFORMANCE_TUNER_STATE_COMMAND, WEB_POOLS_COMMAND,
+        WEB_VERSION_COMMAND,
     };
 
     #[tokio::test]
@@ -865,6 +917,13 @@ mod tests {
                 parameters: None,
             },
             Value::from_str(WEB_PERFORMANCE_TUNER_STATE_COMMAND).unwrap(),
+        );
+        results.insert(
+            MinerCommand::WebAPI {
+                command: "configuration/miner",
+                parameters: None,
+            },
+            Value::from_str(WEB_MINER_CONFIGURATION_COMMAND).unwrap(),
         );
         results.insert(
             miner
@@ -935,9 +994,47 @@ mod tests {
             miner_data.tuning_target,
             Some(TuningTarget::Power(Power::from_watts(3500.0)))
         );
+        assert_eq!(
+            miner_data.scaled_tuning_target,
+            Some(TuningTarget::Power(Power::from_watts(3500.0)))
+        );
         assert_eq!(miner_data.pools.len(), 1);
         assert_eq!(miner_data.pools[0].len(), 2);
         assert!(miner_data.hashrate.is_some());
         assert!(miner_data.expected_hashrate.is_some());
+    }
+
+    #[test]
+    fn test_braiins_v26_04_tuner_mode_selects_hashrate_targets() {
+        let miner = BraiinsV2604::new(IpAddr::from([127, 0, 0, 1]), AntMinerModel::S21Pro);
+        let mut data = HashMap::new();
+
+        data.insert(
+            DataField::TuningTarget,
+            json!({
+                "mode": 2,
+                "configured_power": 3500.0,
+                "configured_hashrate": 230.0,
+                "scaled_power": 3300.0,
+                "scaled_hashrate": 215.5,
+            }),
+        );
+
+        assert_eq!(
+            miner.parse_tuning_target(&data),
+            Some(TuningTarget::HashRate(HashRate {
+                value: 230.0,
+                unit: HashRateUnit::TeraHash,
+                algo: "SHA256".to_string(),
+            }))
+        );
+        assert_eq!(
+            miner.parse_scaled_tuning_target(&data),
+            Some(TuningTarget::HashRate(HashRate {
+                value: 215.5,
+                unit: HashRateUnit::TeraHash,
+                algo: "SHA256".to_string(),
+            }))
+        );
     }
 }

--- a/asic-rs-firmwares/braiins/src/test/json/v21_09/gql_boards.json
+++ b/asic-rs-firmwares/braiins/src/test/json/v21_09/gql_boards.json
@@ -1,75 +1,77 @@
 {
-  "bosminer": {
-    "info": {
-      "workSolver": {
-        "childSolvers": [
-          {
-            "hwDetails": {
-              "chips": 63,
-              "frequencyMhz": 420.170944,
-              "voltageV": 9.097456932067873
-            },
-            "name": "6",
-            "nominalMhs": 3017667.7198079997,
-            "realHashrate": {
-              "mhs5S": 2966950.3918025643
-            },
-            "temperatures": [
-              {
-                "degreesC": 71,
-                "name": "Board"
+  "data": {
+    "bosminer": {
+      "info": {
+        "workSolver": {
+          "childSolvers": [
+            {
+              "hwDetails": {
+                "chips": 63,
+                "frequencyMhz": 420.170944,
+                "voltageV": 9.097456932067873
               },
-              {
-                "degreesC": 81.625,
-                "name": "Chip"
-              }
-            ]
-          },
-          {
-            "hwDetails": {
-              "chips": 63,
-              "frequencyMhz": 420.170944,
-              "voltageV": 9.097456932067873
-            },
-            "name": "7",
-            "nominalMhs": 3017667.7198079997,
-            "realHashrate": {
-              "mhs5S": 3022858.545443969
-            },
-            "temperatures": [
-              {
-                "degreesC": 75.375,
-                "name": "Board"
+              "name": "6",
+              "nominalMhs": 3017667.7198079997,
+              "realHashrate": {
+                "mhs5S": 2966950.3918025643
               },
-              {
-                "degreesC": 89.25,
-                "name": "Chip"
-              }
-            ]
-          },
-          {
-            "hwDetails": {
-              "chips": 63,
-              "frequencyMhz": 420.170944,
-              "voltageV": 9.097456932067873
+              "temperatures": [
+                {
+                  "degreesC": 71,
+                  "name": "Board"
+                },
+                {
+                  "degreesC": 81.625,
+                  "name": "Chip"
+                }
+              ]
             },
-            "name": "8",
-            "nominalMhs": 3017667.7198079997,
-            "realHashrate": {
-              "mhs5S": 2946869.1247815643
-            },
-            "temperatures": [
-              {
-                "degreesC": 66.125,
-                "name": "Board"
+            {
+              "hwDetails": {
+                "chips": 63,
+                "frequencyMhz": 420.170944,
+                "voltageV": 9.097456932067873
               },
-              {
-                "degreesC": 80,
-                "name": "Chip"
-              }
-            ]
-          }
-        ]
+              "name": "7",
+              "nominalMhs": 3017667.7198079997,
+              "realHashrate": {
+                "mhs5S": 3022858.545443969
+              },
+              "temperatures": [
+                {
+                  "degreesC": 75.375,
+                  "name": "Board"
+                },
+                {
+                  "degreesC": 89.25,
+                  "name": "Chip"
+                }
+              ]
+            },
+            {
+              "hwDetails": {
+                "chips": 63,
+                "frequencyMhz": 420.170944,
+                "voltageV": 9.097456932067873
+              },
+              "name": "8",
+              "nominalMhs": 3017667.7198079997,
+              "realHashrate": {
+                "mhs5S": 2946869.1247815643
+              },
+              "temperatures": [
+                {
+                  "degreesC": 66.125,
+                  "name": "Board"
+                },
+                {
+                  "degreesC": 80,
+                  "name": "Chip"
+                }
+              ]
+            }
+          ]
+        }
       }
     }
   }

--- a/asic-rs-firmwares/braiins/src/test/json/v21_09/gql_pools.json
+++ b/asic-rs-firmwares/braiins/src/test/json/v21_09/gql_pools.json
@@ -1,54 +1,56 @@
 {
-  "bosminer": {
-    "config": {
-      "groups": [
-        {
-          "id": "0",
-          "strategy": {
-            "quota": 1
-          }
-        },
-        {
-          "id": "2",
-          "strategy": {
-            "quota": 1
-          }
-        }
-      ]
-    },
-    "info": {
-      "poolGroups": [
-        {
-          "name": "group",
-          "pools": [
-            {
-              "active": true,
-              "shares": {
-                "acceptedSolutions": 31,
-                "rejectedSolutions": 0
-              },
-              "status": "ALIVE",
-              "url": "stratum+tcp://btc1.example.pool:3333",
-              "user": "asic-rs.test"
+  "data": {
+    "bosminer": {
+      "config": {
+        "groups": [
+          {
+            "id": "0",
+            "strategy": {
+              "quota": 1
             }
-          ]
-        },
-        {
-          "name": "test",
-          "pools": [
-            {
-              "active": true,
-              "shares": {
-                "acceptedSolutions": 18,
-                "rejectedSolutions": 0
-              },
-              "status": "ALIVE",
-              "url": "stratum+tcp://btc2.example.pool:3333",
-              "user": "asic-rs.test"
+          },
+          {
+            "id": "2",
+            "strategy": {
+              "quota": 1
             }
-          ]
-        }
-      ]
+          }
+        ]
+      },
+      "info": {
+        "poolGroups": [
+          {
+            "name": "group",
+            "pools": [
+              {
+                "active": true,
+                "shares": {
+                  "acceptedSolutions": 31,
+                  "rejectedSolutions": 0
+                },
+                "status": "ALIVE",
+                "url": "stratum+tcp://btc1.example.pool:3333",
+                "user": "asic-rs.test"
+              }
+            ]
+          },
+          {
+            "name": "test",
+            "pools": [
+              {
+                "active": true,
+                "shares": {
+                  "acceptedSolutions": 18,
+                  "rejectedSolutions": 0
+                },
+                "status": "ALIVE",
+                "url": "stratum+tcp://btc2.example.pool:3333",
+                "user": "asic-rs.test"
+              }
+            ]
+          }
+        ]
+      }
     }
   }
 }

--- a/asic-rs-firmwares/braiins/src/test/json/v21_09/gql_system.json
+++ b/asic-rs-firmwares/braiins/src/test/json/v21_09/gql_system.json
@@ -1,50 +1,52 @@
 {
-  "bos": {
-    "faultLight": false,
-    "hostname": "miner-60726c",
-    "info": {
-      "version": {
-        "full": "2022-09-13-0-11012d53-22.08-plus"
-      }
-    },
-    "uptime": {
-      "durationS": 1189
-    }
-  },
-  "bosminer": {
-    "info": {
-      "fans": [
-        {
-          "name": "0",
-          "rpm": 4080,
-          "speed": 100
-        },
-        {
-          "name": "1",
-          "rpm": 5580,
-          "speed": 100
-        },
-        {
-          "name": "2",
-          "rpm": 0,
-          "speed": 100
-        },
-        {
-          "name": "3",
-          "rpm": 0,
-          "speed": 100
-        }
-      ],
-      "summary": {
-        "power": {
-          "approxConsumptionW": 735,
-          "limitW": 900
+  "data": {
+    "bos": {
+      "faultLight": false,
+      "hostname": "miner-60726c",
+      "info": {
+        "version": {
+          "full": "2022-09-13-0-11012d53-22.08-plus"
         }
       },
-      "workSolver": {
-        "nominalMhs": 7242402.52323,
-        "realHashrate": {
-          "mhs5S": 7160208.944955902
+      "uptime": {
+        "durationS": 1189
+      }
+    },
+    "bosminer": {
+      "info": {
+        "fans": [
+          {
+            "name": "0",
+            "rpm": 4080,
+            "speed": 100
+          },
+          {
+            "name": "1",
+            "rpm": 5580,
+            "speed": 100
+          },
+          {
+            "name": "2",
+            "rpm": 0,
+            "speed": 100
+          },
+          {
+            "name": "3",
+            "rpm": 0,
+            "speed": 100
+          }
+        ],
+        "summary": {
+          "power": {
+            "approxConsumptionW": 735,
+            "limitW": 900
+          }
+        },
+        "workSolver": {
+          "nominalMhs": 7242402.52323,
+          "realHashrate": {
+            "mhs5S": 7160208.944955902
+          }
         }
       }
     }

--- a/asic-rs-firmwares/braiins/src/test/json/v21_09/gql_tuning.json
+++ b/asic-rs-firmwares/braiins/src/test/json/v21_09/gql_tuning.json
@@ -1,0 +1,20 @@
+{
+  "data": {
+    "bosminer": {
+      "config": {
+        "autotuning": {
+          "hashrateTarget": null,
+          "mode": "POWER_TARGET",
+          "powerTarget": 900
+        }
+      },
+      "info": {
+        "summary": {
+          "power": {
+            "limitW": 900
+          }
+        }
+      }
+    }
+  }
+}

--- a/asic-rs-firmwares/braiins/src/test/json/v21_09/mod.rs
+++ b/asic-rs-firmwares/braiins/src/test/json/v21_09/mod.rs
@@ -3,5 +3,6 @@
 pub(crate) const GQL_BOARDS_COMMAND: &str = include_str!("gql_boards.json");
 pub(crate) const GQL_POOLS_COMMAND: &str = include_str!("gql_pools.json");
 pub(crate) const GQL_SYSTEM_COMMAND: &str = include_str!("gql_system.json");
+pub(crate) const GQL_TUNING_COMMAND: &str = include_str!("gql_tuning.json");
 pub(crate) const VERSION_COMMAND: &str = include_str!("version.json");
 pub(crate) const WEB_NET_CONF_COMMAND: &str = include_str!("web_net_conf.json");

--- a/asic-rs-firmwares/braiins/src/test/json/v24_09/gql_tuning.json
+++ b/asic-rs-firmwares/braiins/src/test/json/v24_09/gql_tuning.json
@@ -1,0 +1,20 @@
+{
+  "data": {
+    "bosminer": {
+      "config": {
+        "autotuning": {
+          "hashrateTarget": null,
+          "mode": "POWER_TARGET",
+          "powerTarget": 900
+        }
+      },
+      "info": {
+        "summary": {
+          "power": {
+            "limitW": 900
+          }
+        }
+      }
+    }
+  }
+}

--- a/asic-rs-firmwares/braiins/src/test/json/v24_09/mod.rs
+++ b/asic-rs-firmwares/braiins/src/test/json/v24_09/mod.rs
@@ -1,7 +1,9 @@
 #![cfg(test)]
 
 pub(crate) const GQL_BOARDS_COMMAND: &str = include_str!("gql_boards.json");
+pub(crate) const GQL_EVENTS_COMMAND: &str = include_str!("gql_events.json");
 pub(crate) const GQL_POOLS_COMMAND: &str = include_str!("gql_pools.json");
 pub(crate) const GQL_SYSTEM_COMMAND: &str = include_str!("gql_system.json");
+pub(crate) const GQL_TUNING_COMMAND: &str = include_str!("gql_tuning.json");
 pub(crate) const VERSION_COMMAND: &str = include_str!("version.json");
 pub(crate) const WEB_NET_CONF_COMMAND: &str = include_str!("web_net_conf.json");

--- a/asic-rs-firmwares/braiins/src/test/json/v25_03/gql_tuning.json
+++ b/asic-rs-firmwares/braiins/src/test/json/v25_03/gql_tuning.json
@@ -1,0 +1,20 @@
+{
+  "data": {
+    "bosminer": {
+      "config": {
+        "autotuning": {
+          "hashrateTarget": null,
+          "mode": "POWER_TARGET",
+          "powerTarget": 3878
+        }
+      },
+      "info": {
+        "summary": {
+          "power": {
+            "limitW": 3878
+          }
+        }
+      }
+    }
+  }
+}

--- a/asic-rs-firmwares/braiins/src/test/json/v25_03/mod.rs
+++ b/asic-rs-firmwares/braiins/src/test/json/v25_03/mod.rs
@@ -4,5 +4,6 @@ pub(crate) const GQL_BOARDS_COMMAND: &str = include_str!("gql_boards.json");
 pub(crate) const GQL_EVENTS_COMMAND: &str = include_str!("gql_events.json");
 pub(crate) const GQL_POOLS_COMMAND: &str = include_str!("gql_pools.json");
 pub(crate) const GQL_SYSTEM_COMMAND: &str = include_str!("gql_system.json");
+pub(crate) const GQL_TUNING_COMMAND: &str = include_str!("gql_tuning.json");
 pub(crate) const VERSION_COMMAND: &str = include_str!("version.json");
 pub(crate) const WEB_NET_CONF_COMMAND: &str = include_str!("web_net_conf.json");

--- a/asic-rs-firmwares/braiins/src/test/json/v25_05/gql_tuning.json
+++ b/asic-rs-firmwares/braiins/src/test/json/v25_05/gql_tuning.json
@@ -1,0 +1,20 @@
+{
+  "data": {
+    "bosminer": {
+      "config": {
+        "autotuning": {
+          "hashrateTarget": null,
+          "mode": "POWER_TARGET",
+          "powerTarget": 3878
+        }
+      },
+      "info": {
+        "summary": {
+          "power": {
+            "limitW": 3878
+          }
+        }
+      }
+    }
+  }
+}

--- a/asic-rs-firmwares/braiins/src/test/json/v25_05/mod.rs
+++ b/asic-rs-firmwares/braiins/src/test/json/v25_05/mod.rs
@@ -4,5 +4,6 @@ pub(crate) const GQL_BOARDS_COMMAND: &str = include_str!("gql_boards.json");
 pub(crate) const GQL_EVENTS_COMMAND: &str = include_str!("gql_events.json");
 pub(crate) const GQL_POOLS_COMMAND: &str = include_str!("gql_pools.json");
 pub(crate) const GQL_SYSTEM_COMMAND: &str = include_str!("gql_system.json");
+pub(crate) const GQL_TUNING_COMMAND: &str = include_str!("gql_tuning.json");
 pub(crate) const VERSION_COMMAND: &str = include_str!("version.json");
 pub(crate) const WEB_NET_CONF_COMMAND: &str = include_str!("web_net_conf.json");

--- a/asic-rs-firmwares/braiins/src/test/json/v25_07/configuration_miner.json
+++ b/asic-rs-firmwares/braiins/src/test/json/v25_07/configuration_miner.json
@@ -1,0 +1,11 @@
+{
+  "pool_groups": [],
+  "tuner": {
+    "enabled": true,
+    "hashrate_target": null,
+    "power_target": {
+      "watt": 3031
+    },
+    "tuner_mode": 1
+  }
+}

--- a/asic-rs-firmwares/braiins/src/test/json/v25_07/mod.rs
+++ b/asic-rs-firmwares/braiins/src/test/json/v25_07/mod.rs
@@ -6,6 +6,7 @@ pub(crate) const WEB_MINER_DETAILS_COMMAND: &str = include_str!("miner_details.j
 pub(crate) const WEB_MINER_STATS_COMMAND: &str = include_str!("miner_stats.json");
 pub(crate) const WEB_PERFORMANCE_TUNER_STATE_COMMAND: &str =
     include_str!("performance_tuner_state.json");
+pub(crate) const WEB_MINER_CONFIGURATION_COMMAND: &str = include_str!("configuration_miner.json");
 pub(crate) const WEB_MINER_ERRORS_COMMAND: &str = include_str!("miner_errors.json");
 pub(crate) const WEB_POOLS_COMMAND: &str = include_str!("pools.json");
 pub(crate) const WEB_COOLING_STATE_COMMAND: &str = include_str!("cooling_state.json");

--- a/asic-rs-firmwares/braiins/src/test/json/v25_11/configuration_miner.json
+++ b/asic-rs-firmwares/braiins/src/test/json/v25_11/configuration_miner.json
@@ -1,0 +1,11 @@
+{
+  "pool_groups": [],
+  "tuner": {
+    "enabled": true,
+    "hashrate_target": null,
+    "power_target": {
+      "watt": 3031
+    },
+    "tuner_mode": 1
+  }
+}

--- a/asic-rs-firmwares/braiins/src/test/json/v25_11/mod.rs
+++ b/asic-rs-firmwares/braiins/src/test/json/v25_11/mod.rs
@@ -6,6 +6,7 @@ pub(crate) const WEB_MINER_DETAILS_COMMAND: &str = include_str!("miner_details.j
 pub(crate) const WEB_MINER_STATS_COMMAND: &str = include_str!("miner_stats.json");
 pub(crate) const WEB_PERFORMANCE_TUNER_STATE_COMMAND: &str =
     include_str!("performance_tuner_state.json");
+pub(crate) const WEB_MINER_CONFIGURATION_COMMAND: &str = include_str!("configuration_miner.json");
 pub(crate) const WEB_MINER_ERRORS_COMMAND: &str = include_str!("miner_errors.json");
 pub(crate) const WEB_POOLS_COMMAND: &str = include_str!("pools.json");
 pub(crate) const WEB_COOLING_STATE_COMMAND: &str = include_str!("cooling_state.json");

--- a/asic-rs-firmwares/braiins/src/test/json/v26_04/configuration_miner.json
+++ b/asic-rs-firmwares/braiins/src/test/json/v26_04/configuration_miner.json
@@ -1,0 +1,11 @@
+{
+  "pool_groups": [],
+  "tuner": {
+    "enabled": true,
+    "hashrate_target": null,
+    "power_target": {
+      "watt": 3500
+    },
+    "tuner_mode": 1
+  }
+}

--- a/asic-rs-firmwares/braiins/src/test/json/v26_04/mod.rs
+++ b/asic-rs-firmwares/braiins/src/test/json/v26_04/mod.rs
@@ -6,6 +6,7 @@ pub(crate) const WEB_MINER_DETAILS_COMMAND: &str = include_str!("miner_details.j
 pub(crate) const WEB_MINER_STATS_COMMAND: &str = include_str!("miner_stats.json");
 pub(crate) const WEB_PERFORMANCE_TUNER_STATE_COMMAND: &str =
     include_str!("performance_tuner_state.json");
+pub(crate) const WEB_MINER_CONFIGURATION_COMMAND: &str = include_str!("configuration_miner.json");
 pub(crate) const WEB_MINER_ERRORS_COMMAND: &str = include_str!("miner_errors.json");
 pub(crate) const WEB_POOLS_COMMAND: &str = include_str!("pools.json");
 pub(crate) const WEB_COOLING_STATE_COMMAND: &str = include_str!("cooling_state.json");


### PR DESCRIPTION
The current implementation for the newer REST API based backends was using scaled tuning target as the tuning target, which could cause some confusion.

For example, if the power limit was set to 3kw, and scaling had backed it off to 2.4kw, it would show the tuning target as 2.4kw, which was only partially correct.