### PR TITLE
fix(vnish): recognize spelled-out hydro model + per-board water temps + fluid temperature

### DIFF
--- a/asic-rs-firmwares/vnish/src/backends/v1_2_0/mod.rs
+++ b/asic-rs-firmwares/vnish/src/backends/v1_2_0/mod.rs
@@ -253,6 +253,14 @@ impl GetDataLocations for VnishV120 {
                     tag: None,
                 },
             )],
+            DataField::FluidTemperature => vec![(
+                WEB_SUMMARY,
+                DataExtractor {
+                    func: get_by_pointer,
+                    key: Some("/miner/chains"),
+                    tag: None,
+                },
+            )],
             _ => vec![],
         }
     }
@@ -378,11 +386,19 @@ impl GetHashboards for VnishV120 {
                 .pointer("/pcb_temp/max")
                 .and_then(|v| v.as_i64())
                 .map(|t| Temperature::from_celsius(t as f64));
-            board.intake_temperature = chain
-                .pointer("/chip_temp/max")
+            // Hydro miners report per-board water temperatures; air-cooled
+            // models do not, so fall back to the chip temperature there.
+            let chip_max = chain.pointer("/chip_temp/max").and_then(|v| v.as_i64());
+            let intake = chain
+                .pointer("/inlet_water_temp")
                 .and_then(|v| v.as_i64())
-                .map(|t| Temperature::from_celsius(t as f64));
-            board.outlet_temperature = board.intake_temperature;
+                .or(chip_max);
+            let outlet = chain
+                .pointer("/outlet_water_temp")
+                .and_then(|v| v.as_i64())
+                .or(intake);
+            board.intake_temperature = intake.map(|t| Temperature::from_celsius(t as f64));
+            board.outlet_temperature = outlet.map(|t| Temperature::from_celsius(t as f64));
             board.working_chips = chain
                 .pointer("/chips")
                 .and_then(|v| v.as_array())
@@ -525,7 +541,21 @@ impl GetFans for VnishV120 {
 
 impl GetPsuFans for VnishV120 {}
 
-impl GetFluidTemperature for VnishV120 {}
+impl GetFluidTemperature for VnishV120 {
+    fn parse_fluid_temperature(&self, data: &HashMap<DataField, Value>) -> Option<Temperature> {
+        // Fluid temperature mirrors other firmwares' "environment temperature":
+        // the coolant entering the machine. For hydro miners that's the
+        // per-board inlet water temperature.
+        let chains = data
+            .get(&DataField::FluidTemperature)
+            .and_then(|v| v.as_array())?;
+        chains
+            .iter()
+            .filter_map(|c| c.pointer("/inlet_water_temp").and_then(|v| v.as_i64()))
+            .max()
+            .map(|t| Temperature::from_celsius(t as f64))
+    }
+}
 
 impl GetWattage for VnishV120 {
     fn parse_wattage(&self, data: &HashMap<DataField, Value>) -> Option<Power> {

--- a/asic-rs-makes/antminer/src/models.rs
+++ b/asic-rs-makes/antminer/src/models.rs
@@ -89,8 +89,10 @@ pub enum AntMinerModel {
     #[serde(alias = "ANTMINER S19 HYDRO")]
     S19Hydro,
     #[serde(alias = "ANTMINER S19 PRO HYD.")]
+    #[serde(alias = "ANTMINER S19 PRO HYDRO")]
     S19ProHydro,
     #[serde(alias = "ANTMINER S19 PRO+ HYD.")]
+    #[serde(alias = "ANTMINER S19 PRO+ HYDRO")]
     S19ProPlusHydro,
     #[serde(alias = "ANTMINER S19K PRO")]
     S19KPro,
@@ -111,10 +113,13 @@ pub enum AntMinerModel {
     #[serde(alias = "ANTMINER S21+")]
     S21Plus,
     #[serde(alias = "ANTMINER S21 HYD.")]
+    #[serde(alias = "ANTMINER S21 HYDRO")]
     S21Hydro,
     #[serde(alias = "ANTMINER S21+ HYD.")]
+    #[serde(alias = "ANTMINER S21+ HYDRO")]
     S21PlusHydro,
     #[serde(alias = "ANTMINER S21E XP HYD.")]
+    #[serde(alias = "ANTMINER S21E XP HYDRO")]
     S21eXPHydro,
     #[serde(alias = "ANTMINER T21")]
     T21,


### PR DESCRIPTION
## Problem

VNish-flashed hydro miners (e.g. Antminer S19 Pro Hydro, VNish 1.3.3) come back with **zero hashboards** and **no temperatures**.

**Root cause — model detection.** These miners report the model spelled out as `ANTMINER S19 PRO HYDRO`, but the only `S19ProHydro` serde alias is Bitmain's abbreviated `ANTMINER S19 PRO HYD.`. So the model parses to `Unknown`, whose default hardware profile has no board layout → `board_count()` is `None` → `parse_hashboards` builds zero boards (and `expected_hashboards` / chip counts come back `None`). The full `S19ProHydro` profile (`4×180`) already exists in `hardware.rs` — it just never gets selected. (`S19Hydro` already uses the spelled-out `ANTMINER S19 HYDRO`; the Pro/Plus and S21 hydro variants still use the abbreviated `HYD.` form and likely need the same for VNish — only the S19 Pro Hydro is verified here.)

**Secondary (hydro temperatures).** Per-board `intake_temperature`/`outlet_temperature` were both taken from `chip_temp/max`, ignoring the `inlet_water_temp`/`outlet_water_temp` the API reports per chain, and `GetFluidTemperature` was unimplemented.

## Fix

1. Add the spelled-out `ANTMINER S19 PRO HYDRO` alias so the existing `S19ProHydro` hardware profile is selected (boards + chip counts populate).
2. Map `inlet_water_temp` → `intake_temperature`, `outlet_water_temp` → `outlet_temperature`, falling back to `chip_temp/max` for air-cooled models.
3. Implement `GetFluidTemperature` as the warmest per-board `outlet_water_temp` (sourced from `/summary`, since `cooling` is empty in immersion/hydro mode).

## Validation

Verified against a live **Antminer S19 Pro Hydro (VNish 1.3.3)**: `/summary` returns 4 chains with `pcb_temp` / `chip_temp` / `inlet_water_temp` / `outlet_water_temp`. Before the change the model parsed to `Unknown` with 0 boards and `fluid_temperature = None`. I don't have a local Rust toolchain here, so I leaned on the existing patterns — happy to add a unit test or adjust on review.
