### PR TITLE
fix(pydantic): serialize Duration as timedelta, not float

### DIFF
--- a/asic-rs-pydantic/src/lib.rs
+++ b/asic-rs-pydantic/src/lib.rs
@@ -183,10 +183,6 @@ impl PyPydanticType for MacAddr {
     }
 }
 
-fn duration_to_seconds(duration: Duration) -> f64 {
-    duration.as_secs() as f64
-}
-
 impl PyPydanticType for Duration {
     fn pydantic_schema<'py>(
         core_schema: &Bound<'py, PyAny>,
@@ -194,7 +190,7 @@ impl PyPydanticType for Duration {
     ) -> PyResult<Bound<'py, PyAny>> {
         match mode {
             PydanticSchemaMode::Validation => core_schema.call_method0("any_schema"),
-            PydanticSchemaMode::Serialization => core_schema.call_method0("float_schema"),
+            PydanticSchemaMode::Serialization => core_schema.call_method0("timedelta_schema"),
         }
     }
 
@@ -218,10 +214,11 @@ impl PyPydanticType for Duration {
     }
 
     fn to_pydantic_data(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
-        Ok(duration_to_seconds(*self)
-            .into_pyobject(py)?
-            .into_any()
-            .unbind())
+        // Expose Duration as a Python `datetime.timedelta` (pyo3 native), so it
+        // round-trips with `from_pydantic` (which already accepts timedelta) and
+        // matches the `get_uptime()` method. Previously serialized as a bare
+        // float (seconds), which broke `.total_seconds()` on consumers.
+        Ok((*self).into_pyobject(py)?.into_any().unbind())
     }
 }
 

--- a/python/tests/test_pydantic_interop.py
+++ b/python/tests/test_pydantic_interop.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import inspect
+from datetime import timedelta
 from typing import Any
 
 import pytest
@@ -644,11 +645,13 @@ def test_nested_data_model_round_trips_hashrate_payload() -> None:
     }
 
 
-def test_miner_data_serializes_uptime_seconds() -> None:
+def test_miner_data_serializes_uptime_as_timedelta() -> None:
     model = MinerDataModel.model_validate({"miner": minimal_miner_data(uptime=1.25)})
 
     assert isinstance(model.miner, MinerData)
-    assert model.model_dump()["miner"]["uptime"] == 1.0
+    # uptime is a Duration -> serialized as datetime.timedelta (matches the
+    # `uptime` type stub and the get_uptime() method), not a bare float.
+    assert model.model_dump()["miner"]["uptime"] == timedelta(seconds=1.25)
 
 
 def test_miner_data_control_board_uses_model_shape() -> None:


### PR DESCRIPTION
### Problem
`MinerData` fields typed `Option<Duration>` (notably `uptime`) are serialized to Python as a **bare float (seconds)**: `to_pydantic_data` calls `duration_to_seconds()` and the serialization schema is `float_schema`. Consumers that treat the value as a duration crash:

```
'float' object has no attribute 'total_seconds'
```

This is also **inconsistent within the library**:
- `from_pydantic` already accepts a `timedelta` (it's the first form in its own error message: *"Expected duration as timedelta, …"*).
- The `Miner.get_uptime()` method already returns `Optional[datetime.timedelta]` (its docstring says so).

So only the `MinerData.uptime` **field** comes through as a float, while the equivalent method returns a `timedelta`.

### Fix
Emit a `datetime.timedelta` from `to_pydantic_data` (pyo3 converts `std::time::Duration` natively) and use `timedelta_schema` for serialization. `from_pydantic` is unchanged and still accepts `timedelta`, non-negative seconds, or `{secs}` dict — so existing inputs keep working; only the output type becomes the (already-expected) `timedelta`.

### Verified
Built a wheel with this change and ran it under Home Assistant against a live miner (BraiinsOS S19k Pro). Before: the `uptime` sensor crashed every update with the `total_seconds` error. After: `uptime` populates normally (e.g. `1308 s`) and no errors in the log; other fields unaffected.

### Note
This changes the serialized type of all `Duration` fields from `float` to `timedelta`. That's the type `from_pydantic`/`get_uptime` already imply, but flagging it in case any consumer relied on the float form.