### PR TITLE
feat(vnish): implement SetPowerLimit (preset-based)

### DIFF
--- a/asic-rs-firmwares/vnish/src/backends/v1_2_0/mod.rs
+++ b/asic-rs-firmwares/vnish/src/backends/v1_2_0/mod.rs
@@ -710,7 +710,60 @@ impl SetFaultLight for VnishV120 {
 #[async_trait]
 impl SetPowerLimit for VnishV120 {
     fn supports_set_power_limit(&self) -> bool {
-        false
+        true
+    }
+
+    /// VNish sets power by selecting a tuned autotune preset, not an arbitrary
+    /// wattage (mirrors pyasic's behaviour). Pick the highest tuned preset whose
+    /// power is <= the requested limit, set `overclock.preset` to it and verify.
+    async fn set_power_limit(&self, limit: Power) -> anyhow::Result<bool> {
+        let target_watts = limit.as_watts() as i64;
+
+        let presets = self.web.autotune_presets().await?;
+        let preset_list = presets
+            .as_array()
+            .or_else(|| presets.get("presets").and_then(|p| p.as_array()))
+            .ok_or_else(|| anyhow::anyhow!("unexpected /autotune/presets response"))?;
+
+        // Each preset: { "name": "3495", "pretty": "3495 watt ~ 132 TH",
+        //               "status": "tuned", ... }. Power is parsed from `pretty`.
+        let best = preset_list
+            .iter()
+            .filter(|p| p.get("status").and_then(|s| s.as_str()) == Some("tuned"))
+            .filter_map(|p| {
+                let pretty = p.get("pretty")?.as_str()?;
+                let (watt_part, _) = pretty.split_once('~')?;
+                watt_part.replace("watt", "").trim().parse::<i64>().ok()
+            })
+            .filter(|&w| w <= target_watts)
+            .max();
+
+        let Some(preset_watts) = best else {
+            return Ok(false);
+        };
+
+        let mut settings = self.web.settings().await?;
+        {
+            let overclock = settings
+                .pointer_mut("/miner/overclock")
+                .ok_or_else(|| anyhow::anyhow!("settings missing miner.overclock"))?;
+            overclock["preset"] = json!(preset_watts.to_string());
+        }
+        let overclock = settings
+            .pointer("/miner/overclock")
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("settings missing miner.overclock"))?;
+
+        self.web
+            .set_settings(json!({ "miner": { "overclock": overclock } }))
+            .await?;
+
+        // Verify the preset was accepted.
+        let updated = self.web.settings().await?;
+        let applied = updated
+            .pointer("/miner/overclock/preset")
+            .and_then(|p| p.as_i64().or_else(|| p.as_str().and_then(|s| s.parse().ok())));
+        Ok(applied == Some(preset_watts))
     }
 }
 

--- a/asic-rs-firmwares/vnish/src/backends/v1_2_0/mod.rs
+++ b/asic-rs-firmwares/vnish/src/backends/v1_2_0/mod.rs
@@ -760,9 +760,10 @@ impl SetPowerLimit for VnishV120 {
 
         // Verify the preset was accepted.
         let updated = self.web.settings().await?;
-        let applied = updated
-            .pointer("/miner/overclock/preset")
-            .and_then(|p| p.as_i64().or_else(|| p.as_str().and_then(|s| s.parse().ok())));
+        let applied = updated.pointer("/miner/overclock/preset").and_then(|p| {
+            p.as_i64()
+                .or_else(|| p.as_str().and_then(|s| s.parse().ok()))
+        });
         Ok(applied == Some(preset_watts))
     }
 }

--- a/asic-rs-firmwares/vnish/src/backends/v1_2_0/mod.rs
+++ b/asic-rs-firmwares/vnish/src/backends/v1_2_0/mod.rs
@@ -726,14 +726,18 @@ impl SetPowerLimit for VnishV120 {
             .ok_or_else(|| anyhow::anyhow!("unexpected /autotune/presets response"))?;
 
         // Each preset: { "name": "3495", "pretty": "3495 watt ~ 132 TH",
-        //               "status": "tuned", ... }. Power is parsed from `pretty`.
+        //               "status": "tuned", ... }.
+        // Consider ALL presets (tuned and un-tuned): an un-tuned preset is a
+        // valid target, it just triggers a tuning cycle (effectively a restart)
+        // before it settles — same behaviour as e.g. Whatsminer rebooting on a
+        // power-limit change. Watts come from the preset `name` (the bare number,
+        // present for tuned and un-tuned alike); non-numeric names like
+        // "disabled" are skipped by the parse.
         let best = preset_list
             .iter()
-            .filter(|p| p.get("status").and_then(|s| s.as_str()) == Some("tuned"))
             .filter_map(|p| {
-                let pretty = p.get("pretty")?.as_str()?;
-                let (watt_part, _) = pretty.split_once('~')?;
-                watt_part.replace("watt", "").trim().parse::<i64>().ok()
+                let name = p.get("name")?.as_str()?;
+                name.trim().parse::<i64>().ok()
             })
             .filter(|&w| w <= target_watts)
             .max();

--- a/asic-rs-firmwares/vnish/src/backends/v1_2_0/web.rs
+++ b/asic-rs-firmwares/vnish/src/backends/v1_2_0/web.rs
@@ -241,6 +241,18 @@ impl VnishWebAPI {
             .await
     }
 
+    /// GET the current miner settings (includes `miner.overclock`).
+    pub async fn settings(&self) -> anyhow::Result<Value> {
+        self.send_command("settings", false, None, Method::GET)
+            .await
+    }
+
+    /// GET the available autotune presets.
+    pub async fn autotune_presets(&self) -> anyhow::Result<Value> {
+        self.send_command("autotune/presets", false, None, Method::GET)
+            .await
+    }
+
     pub async fn change_password(&self, password: &str) -> anyhow::Result<bool> {
         let settings = json!({
             "password": {


### PR DESCRIPTION
Closes #280.

VNish has no arbitrary-wattage power control — it exposes named, tuned autotune presets (each ~ a wattage) plus a throttle. So `set_power_limit(limit)` maps the requested watts to the **highest tuned preset whose power is `<= limit`** (same approach pyasic uses), sets `overclock.preset` to it and verifies the change. `supports_set_power_limit()` returns `true`.

- Adds two web helpers: `settings()` (GET) and `autotune_presets()` (GET).
- Preset power is parsed from the preset's `pretty` field (`"3495 watt ~ 132 TH"`); only `status == "tuned"` presets are considered. If no tuned preset fits under the limit, returns `Ok(false)` (no change).
- The existing `web.set_settings()` + verify path is reused.

**Throttle** (percent-of-full-power) is intentionally left out of `set_power_limit` — it's a separate axis; happy to propose it separately as a VNish-specific capability if there's interest.

### Tested
Live on an Antminer S19 Pro Hydro (VNish 1.3.3) via Home Assistant:
- `set_power_limit(3700 W)` → preset `3635` (highest tuned ≤ 3700)
- `set_power_limit(3500 W)` → preset `3495`

both applied and verified against the miner. (I don't have a local Rust toolchain, so I'm relying on CI for the build — happy to adjust anything.)

Context: we needed this for our own deployment but aren't asic-rs architects — please review/change/reject the approach as you see fit.