### PR TITLE
docs: add vnish v1.3.4 API schema

### DIFF
--- a/meta/vnish/v1.3.4/api-doc.json
+++ b/meta/vnish/v1.3.4/api-doc.json
@@ -1,0 +1,5072 @@
+{
+  "components": {
+    "schemas": {
+      "AddApiKeyRes": {
+        "properties": {
+          "status": {
+            "$ref": "#/components/schemas/AddApiKeyStatus"
+          }
+        },
+        "required": [
+          "status"
+        ],
+        "type": "object"
+      },
+      "AddApiKeyStatus": {
+        "enum": [
+          "inserted",
+          "updated",
+          "nochanges"
+        ],
+        "type": "string"
+      },
+      "AddApikeyQuery": {
+        "$ref": "#/components/schemas/ApiKeysJsonItem"
+      },
+      "AdvancedSettingsRaw": {
+        "properties": {
+          "allow_disabling_chains_without_pics": {
+            "description": "Allow disabling boards without PICs",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "asic_boost": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "auto_chip_throttling": {
+            "description": "Automatically adjusts chip frequencies based on temperatures",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "automatic_pause_on_boot": {
+            "description": "The miner automatically switches to pause mode after boot",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "bitmain_disable_volt_comp": {
+            "description": "Disable voltage compensation feature",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "disable_chain_break_protection": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "disable_restart_unbalanced": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "disable_volt_checks": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "downscale_preset_on_failure": {
+            "description": "Automatic preset reduction in case of miner overheating or board break error",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "ignore_broken_sensors": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "ignore_chip_sensors": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "keep_hashing_when_offline": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "max_restart_attempts": {
+            "format": "int32",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "max_startup_delay_time": {
+            "description": "Maximum delay time before mining startup",
+            "format": "int32",
+            "maximum": 300,
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "min_operational_chains": {
+            "format": "int32",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "min_startup_delay_time": {
+            "format": "int32",
+            "maximum": 300,
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "power_limit": {
+            "format": "int32",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "power_limit_enabled": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "quick_start": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "quiet_mode": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "restart_hashrate": {
+            "description": "Percent, `0` to disable",
+            "format": "int32",
+            "maximum": 100,
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "restart_temp": {
+            "format": "int32",
+            "maximum": 120,
+            "minimum": 50,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "restore_miner_state_on_reboot": {
+            "description": "Automatically starts mining after a reboot or power outage, even if mining was previously paused",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "retune_on_chain_break": {
+            "description": "Auto retune on board break",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "tuner_bad_chip_hr_threshold": {
+            "description": "Autotuning: hashrate threshold below which the chips are marked as bad ones",
+            "format": "int32",
+            "maximum": 80,
+            "minimum": 20,
+            "type": [
+              "integer",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "AntmBoard": {
+        "properties": {
+          "chip_statuses": {
+            "$ref": "#/components/schemas/BoardChipStatuses"
+          },
+          "chip_temp": {
+            "$ref": "#/components/schemas/TempRange"
+          },
+          "frequency": {
+            "format": "float",
+            "type": "number"
+          },
+          "hashrate_ideal": {
+            "format": "float",
+            "type": "number"
+          },
+          "hashrate_percentage": {
+            "format": "float",
+            "type": "number"
+          },
+          "hashrate_rt": {
+            "format": "float",
+            "type": "number"
+          },
+          "hr_error": {
+            "format": "float",
+            "type": "number"
+          },
+          "hw_errors": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "id": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "inlet_water_temp": {
+            "format": "int32",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "outlet_water_temp": {
+            "format": "int32",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "pcb_temp": {
+            "$ref": "#/components/schemas/TempRange"
+          },
+          "power_consumption": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "status": {
+            "$ref": "#/components/schemas/BoardStatus"
+          },
+          "voltage": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "frequency",
+          "voltage",
+          "power_consumption",
+          "hashrate_ideal",
+          "hashrate_rt",
+          "hashrate_percentage",
+          "hr_error",
+          "hw_errors",
+          "pcb_temp",
+          "chip_temp",
+          "chip_statuses",
+          "status"
+        ],
+        "type": "object"
+      },
+      "AntmBoardChips": {
+        "properties": {
+          "chips": {
+            "items": {
+              "$ref": "#/components/schemas/AntmChip"
+            },
+            "type": "array"
+          },
+          "freq": {
+            "format": "float",
+            "type": "number"
+          },
+          "hr_nominal": {
+            "format": "float",
+            "type": "number"
+          },
+          "hr_realtime": {
+            "format": "float",
+            "type": "number"
+          },
+          "id": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "sensors": {
+            "items": {
+              "$ref": "#/components/schemas/AntmChipSensor"
+            },
+            "type": "array"
+          },
+          "status": {
+            "$ref": "#/components/schemas/CgBoardStatus"
+          }
+        },
+        "required": [
+          "id",
+          "status",
+          "hr_realtime",
+          "hr_nominal",
+          "freq",
+          "sensors",
+          "chips"
+        ],
+        "type": "object"
+      },
+      "AntmBoardChipsStats": {
+        "properties": {
+          "chips": {
+            "items": {
+              "$ref": "#/components/schemas/AntmiChipStats"
+            },
+            "type": "array"
+          },
+          "id": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "chips"
+        ],
+        "type": "object"
+      },
+      "AntmBoardsChipsStats": {
+        "properties": {
+          "chains": {
+            "items": {
+              "$ref": "#/components/schemas/AntmBoardChipsStats"
+            },
+            "type": "array"
+          },
+          "chips_per_chain": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "chips_per_chain",
+          "chains"
+        ],
+        "type": "object"
+      },
+      "AntmChip": {
+        "properties": {
+          "errs": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "freq": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "grade": {
+            "$ref": "#/components/schemas/ChipGrade"
+          },
+          "hr": {
+            "format": "float",
+            "type": "number"
+          },
+          "id": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "temp": {
+            "format": "float",
+            "type": "number"
+          },
+          "throttled": {
+            "type": "boolean"
+          },
+          "volt": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "hr",
+          "freq",
+          "volt",
+          "temp",
+          "errs",
+          "grade",
+          "throttled"
+        ],
+        "type": "object"
+      },
+      "AntmChipSensor": {
+        "properties": {
+          "board": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "chip": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "loc": {
+            "description": "Location that refers to `chip.id`",
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "state": {
+            "$ref": "#/components/schemas/TempSensorStatus"
+          }
+        },
+        "required": [
+          "state",
+          "board",
+          "chip",
+          "loc"
+        ],
+        "type": "object"
+      },
+      "AntmMinerStats": {
+        "properties": {
+          "average_hashrate": {
+            "deprecated": true,
+            "description": "Deprecated. Same as hr_average but measure is MG/s.",
+            "format": "float",
+            "type": "number"
+          },
+          "best_share": {
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "chains": {
+            "items": {
+              "$ref": "#/components/schemas/AntmBoard"
+            },
+            "type": "array"
+          },
+          "chip_temp": {
+            "$ref": "#/components/schemas/TempRange"
+          },
+          "cooling": {
+            "$ref": "#/components/schemas/Cooling"
+          },
+          "devfee": {
+            "format": "float",
+            "type": "number"
+          },
+          "devfee_percent": {
+            "format": "float",
+            "type": "number"
+          },
+          "found_blocks": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "hr_average": {
+            "format": "float",
+            "type": "number"
+          },
+          "hr_error": {
+            "description": "Errors rate",
+            "format": "float",
+            "type": "number"
+          },
+          "hr_nominal": {
+            "format": "float",
+            "type": "number"
+          },
+          "hr_realtime": {
+            "format": "float",
+            "type": "number"
+          },
+          "hr_stock": {
+            "format": "float",
+            "type": "number"
+          },
+          "hw_errors": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "hw_errors_percent": {
+            "format": "float",
+            "type": "number"
+          },
+          "instant_hashrate": {
+            "deprecated": true,
+            "description": "Deprecated. Same as hr_realtime but measure is MG/s.",
+            "format": "float",
+            "type": "number"
+          },
+          "miner_status": {
+            "$ref": "#/components/schemas/MinerStatus"
+          },
+          "miner_type": {
+            "type": "string"
+          },
+          "pcb_temp": {
+            "$ref": "#/components/schemas/TempRange"
+          },
+          "pools": {
+            "items": {
+              "$ref": "#/components/schemas/PoolStats"
+            },
+            "type": "array"
+          },
+          "power_consumption": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "power_efficiency": {
+            "format": "float",
+            "type": "number"
+          },
+          "power_usage": {
+            "deprecated": true,
+            "description": "Deprecated. Same as power_efficiency",
+            "format": "int32",
+            "type": "integer"
+          },
+          "psu": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/AntmPsuInfo"
+              }
+            ]
+          },
+          "restart_count": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "miner_status",
+          "miner_type",
+          "hr_stock",
+          "average_hashrate",
+          "instant_hashrate",
+          "hr_realtime",
+          "hr_nominal",
+          "hr_average",
+          "pcb_temp",
+          "chip_temp",
+          "power_consumption",
+          "power_usage",
+          "power_efficiency",
+          "hw_errors_percent",
+          "hr_error",
+          "hw_errors",
+          "devfee_percent",
+          "devfee",
+          "pools",
+          "cooling",
+          "chains",
+          "found_blocks",
+          "best_share",
+          "restart_count"
+        ],
+        "type": "object"
+      },
+      "AntmPsuInfo": {
+        "properties": {
+          "psu_power_metering": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "temps": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/AntmPsuTemps"
+              }
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "AntmPsuTemps": {
+        "properties": {
+          "llc1_temp": {
+            "format": "int32",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "llc2_temp": {
+            "format": "int32",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "pfc_temp": {
+            "format": "int32",
+            "type": [
+              "integer",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "AntmiChipStats": {
+        "properties": {
+          "errors": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "freq": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "hashrate": {
+            "format": "float",
+            "type": "number"
+          },
+          "id": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "sensor": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/TempSensor"
+              }
+            ]
+          },
+          "status": {
+            "$ref": "#/components/schemas/ChipGrade"
+          },
+          "temp": {
+            "format": "float",
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "status",
+          "hashrate",
+          "freq",
+          "temp",
+          "errors"
+        ],
+        "type": "object"
+      },
+      "ApiHrMeasure": {
+        "description": "Hashrate measure unit",
+        "enum": [
+          "GH/s",
+          "MH/s",
+          "N/A"
+        ],
+        "type": "string"
+      },
+      "ApiKeysJson": {
+        "items": {
+          "$ref": "#/components/schemas/ApiKeysJsonItem"
+        },
+        "type": "array"
+      },
+      "ApiKeysJsonItem": {
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "key": {
+            "maxLength": 32,
+            "minLength": 32,
+            "type": "string"
+          }
+        },
+        "required": [
+          "key",
+          "description"
+        ],
+        "type": "object"
+      },
+      "ApiMiningAlgorithm": {
+        "enum": [
+          "sha256d",
+          "scrypt",
+          "unknown"
+        ],
+        "type": "string"
+      },
+      "Apikey": {
+        "type": "string"
+      },
+      "AuthCheck": {
+        "properties": {
+          "unlock_timeout": {
+            "format": "int64",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "AutotuneBoard": {
+        "properties": {
+          "chips": {
+            "items": {
+              "format": "int32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "type": "array"
+          },
+          "freq": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "serial": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "freq",
+          "chips"
+        ],
+        "type": "object"
+      },
+      "AutotunePresetDto": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/AutotunePresetsItem"
+          },
+          {
+            "properties": {
+              "tune_settings": {
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "$ref": "#/components/schemas/AutotuneResultsItem"
+                  }
+                ]
+              }
+            },
+            "type": "object"
+          }
+        ]
+      },
+      "AutotunePresetStatus": {
+        "description": "Preset status. `tuned` means that preset tuned successfully",
+        "enum": [
+          "untuned",
+          "tuned"
+        ],
+        "type": "string"
+      },
+      "AutotunePresets": {
+        "items": {
+          "$ref": "#/components/schemas/AutotunePresetsItem"
+        },
+        "type": "array"
+      },
+      "AutotunePresetsItem": {
+        "properties": {
+          "modded_psu_required": {
+            "type": "boolean"
+          },
+          "name": {
+            "description": "Preset id name",
+            "type": "string"
+          },
+          "pretty": {
+            "description": "Preset human-readable name",
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/AutotunePresetStatus"
+          }
+        },
+        "required": [
+          "name",
+          "pretty",
+          "status",
+          "modded_psu_required"
+        ],
+        "type": "object"
+      },
+      "AutotuneReset": {
+        "properties": {
+          "presets": {
+            "description": "List of presets to reset",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "restart": {
+            "description": "Restart after presets remove",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "presets",
+          "restart"
+        ],
+        "type": "object"
+      },
+      "AutotuneResetAll": {
+        "properties": {
+          "restart": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "restart"
+        ],
+        "type": "object"
+      },
+      "AutotuneResultsItem": {
+        "properties": {
+          "chains": {
+            "items": {
+              "$ref": "#/components/schemas/AutotuneBoard"
+            },
+            "type": "array"
+          },
+          "date": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "freq": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "hashrate": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "modified": {
+            "type": "boolean"
+          },
+          "volt": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "hashrate",
+          "volt",
+          "freq",
+          "chains",
+          "modified"
+        ],
+        "type": "object"
+      },
+      "BoardChipStatuses": {
+        "properties": {
+          "grey": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "orange": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "red": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "red",
+          "orange",
+          "grey"
+        ],
+        "type": "object"
+      },
+      "BoardRaw": {
+        "properties": {
+          "chips": {
+            "description": "An array of per chip `freq` settings values.\n`0` (zero) value means that value used from `board` settings",
+            "items": {
+              "format": "int32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "disabled": {
+            "description": "Board `disabled` settings value",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "freq": {
+            "description": "Board `freq` settings values.\n`0` (zero) value means that value used from `globals` settings",
+            "format": "int32",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "BoardState": {
+        "enum": [
+          "initializing",
+          "mining",
+          "stopped",
+          "failure",
+          "disconnected",
+          "disabled",
+          "unknown"
+        ],
+        "type": "string"
+      },
+      "BoardStatus": {
+        "properties": {
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "state": {
+            "$ref": "#/components/schemas/BoardState"
+          }
+        },
+        "required": [
+          "state"
+        ],
+        "type": "object"
+      },
+      "CgBoardStatus": {
+        "properties": {
+          "failure_message": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "state": {
+            "$ref": "#/components/schemas/BoardState"
+          }
+        },
+        "required": [
+          "state"
+        ],
+        "type": "object"
+      },
+      "ChipGrade": {
+        "enum": [
+          "grey",
+          "orange",
+          "red"
+        ],
+        "type": "string"
+      },
+      "Consts": {
+        "properties": {
+          "cooling": {
+            "$ref": "#/components/schemas/CoolingConsts"
+          },
+          "overclock": {
+            "$ref": "#/components/schemas/Overclock"
+          },
+          "timezones": {
+            "description": "Available timezones list.\nA purpose for this field is to display timezones list in UI.\nMakes sense for GET queries only and shall ignore for UPDATE queries.",
+            "items": {
+              "items": false,
+              "prefixItems": [
+                {
+                  "description": "Current timezone name (code)",
+                  "enum": [
+                    "GMT+1",
+                    "GMT+2",
+                    "GMT+3",
+                    "GMT+4",
+                    "GMT+5",
+                    "GMT+6",
+                    "GMT+7",
+                    "GMT+8",
+                    "GMT+9",
+                    "GMT+10",
+                    "GMT+11",
+                    "GMT+12",
+                    "GMT",
+                    "GMT-1",
+                    "GMT-2",
+                    "GMT-3",
+                    "GMT-4",
+                    "GMT-5",
+                    "GMT-6",
+                    "GMT-7",
+                    "GMT-8",
+                    "GMT-9",
+                    "GMT-10",
+                    "GMT-11"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "type": "array"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "cooling",
+          "overclock",
+          "timezones"
+        ],
+        "type": "object"
+      },
+      "Cooling": {
+        "properties": {
+          "fan_duty": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "fan_num": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "fans": {
+            "items": {
+              "$ref": "#/components/schemas/Fan"
+            },
+            "type": "array"
+          },
+          "settings": {
+            "$ref": "#/components/schemas/FanSettings"
+          }
+        },
+        "required": [
+          "fan_num",
+          "fans",
+          "settings",
+          "fan_duty"
+        ],
+        "type": "object"
+      },
+      "CoolingConsts": {
+        "properties": {
+          "fan_min_count": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/MinerFanMinCount"
+              }
+            ]
+          },
+          "max_target_temp": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "min_fan_pwm": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "min_target_temp": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "min_fan_pwm",
+          "min_target_temp",
+          "max_target_temp"
+        ],
+        "type": "object"
+      },
+      "CoolingSettingsRaw": {
+        "properties": {
+          "fan_max_duty": {
+            "format": "int32",
+            "maximum": 100,
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "fan_min_count": {
+            "format": "int32",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "fan_min_duty": {
+            "format": "int32",
+            "maximum": 100,
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "min_startup_water_temp": {
+            "format": "int32",
+            "maximum": 20,
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "mode": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ModeRaw"
+              }
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "CurrentPreset": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/AutotunePresetsItem"
+          },
+          {
+            "properties": {
+              "globals": {
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "$ref": "#/components/schemas/GlobalsRaw",
+                    "description": "Globals passed here when preset is disabled"
+                  }
+                ]
+              }
+            },
+            "type": "object"
+          }
+        ]
+      },
+      "DeleteApikeyQuery": {
+        "properties": {
+          "key": {
+            "maxLength": 32,
+            "minLength": 32,
+            "type": "string"
+          }
+        },
+        "required": [
+          "key"
+        ],
+        "type": "object"
+      },
+      "DiagReportQueryInput": {
+        "properties": {
+          "issue": {
+            "description": "Issue text. Max 16KB",
+            "type": "string"
+          }
+        },
+        "required": [
+          "issue"
+        ],
+        "type": "object"
+      },
+      "ErrDescr": {
+        "properties": {
+          "err": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "err"
+        ],
+        "type": "object"
+      },
+      "FactoryInfoBoard": {
+        "properties": {
+          "board_model": {
+            "type": "string"
+          },
+          "chip_bin": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "freq": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "hashrate": {
+            "format": "double",
+            "type": "number"
+          },
+          "id": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "serial": {
+            "type": "string"
+          },
+          "volt": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "board_model",
+          "serial",
+          "chip_bin",
+          "freq",
+          "volt",
+          "hashrate"
+        ],
+        "type": "object"
+      },
+      "FactoryInfoReply": {
+        "properties": {
+          "chains": {
+            "items": {
+              "$ref": "#/components/schemas/FactoryInfoBoard"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "has_pics": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "hr_stock": {
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "psu_model": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "psu_serial": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "Fan": {
+        "properties": {
+          "id": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "max_rpm": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "rpm": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "status": {
+            "$ref": "#/components/schemas/FanStatus"
+          }
+        },
+        "required": [
+          "id",
+          "rpm",
+          "status",
+          "max_rpm"
+        ],
+        "type": "object"
+      },
+      "FanSettings": {
+        "properties": {
+          "mode": {
+            "$ref": "#/components/schemas/FanSettingsMode"
+          }
+        },
+        "required": [
+          "mode"
+        ],
+        "type": "object"
+      },
+      "FanSettingsMode": {
+        "oneOf": [
+          {
+            "properties": {
+              "name": {
+                "enum": [
+                  "auto"
+                ],
+                "type": "string"
+              },
+              "param": {
+                "format": "int32",
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "param",
+              "name"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "name": {
+                "enum": [
+                  "manual"
+                ],
+                "type": "string"
+              },
+              "param": {
+                "format": "int32",
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "param",
+              "name"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "name": {
+                "enum": [
+                  "immersion"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "FanStatus": {
+        "enum": [
+          "ok",
+          "lost"
+        ],
+        "type": "string"
+      },
+      "FindMinerStatus": {
+        "properties": {
+          "on": {
+            "description": "Locate miner on/off",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "on"
+        ],
+        "type": "object"
+      },
+      "FwInfo": {
+        "properties": {
+          "build_name": {
+            "type": "string"
+          },
+          "build_time": {
+            "description": "Build time",
+            "type": "string"
+          },
+          "build_uuid": {
+            "type": "string"
+          },
+          "fw_name": {
+            "description": "Firmware name",
+            "type": "string"
+          },
+          "fw_version": {
+            "description": "Firmware version",
+            "type": "string"
+          },
+          "install_type": {
+            "$ref": "#/components/schemas/InstallType"
+          },
+          "platform": {
+            "$ref": "#/components/schemas/Platform"
+          }
+        },
+        "required": [
+          "fw_name",
+          "fw_version",
+          "platform",
+          "install_type",
+          "build_time"
+        ],
+        "type": "object"
+      },
+      "FwRemoveParams": {
+        "properties": {
+          "remove_stock_logs": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "remove_stock_logs"
+        ],
+        "type": "object"
+      },
+      "GlobalsRaw": {
+        "properties": {
+          "freq": {
+            "format": "int32",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "volt": {
+            "format": "int32",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "HrMeasure": {
+        "description": "Hashrate measure unit",
+        "enum": [
+          "GH/s",
+          "MH/s"
+        ],
+        "type": "string"
+      },
+      "InfoJson": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/FwInfo"
+          },
+          {
+            "properties": {
+              "algorithm": {
+                "$ref": "#/components/schemas/ApiMiningAlgorithm"
+              },
+              "hr_measure": {
+                "$ref": "#/components/schemas/ApiHrMeasure"
+              },
+              "miner": {
+                "description": "Pretty miner name",
+                "type": "string"
+              },
+              "model": {
+                "description": "Miner model code",
+                "type": "string"
+              },
+              "serial": {
+                "type": "string"
+              },
+              "system": {
+                "$ref": "#/components/schemas/SystemInfo"
+              }
+            },
+            "required": [
+              "miner",
+              "model",
+              "algorithm",
+              "hr_measure",
+              "system",
+              "serial"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "InputConfig": {
+        "properties": {
+          "layout": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/Layout"
+              }
+            ]
+          },
+          "miner": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/MinerConfigRaw"
+              }
+            ]
+          },
+          "network": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/InputNetworkConfFile"
+              }
+            ]
+          },
+          "password": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/PasswordChange"
+              }
+            ]
+          },
+          "regional": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/RegionalSettings"
+              }
+            ]
+          },
+          "ui": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/UiSettings"
+              }
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "InputNetworkConfFile": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/NetworkConfFile"
+          },
+          {
+            "properties": {
+              "enable_network_check": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          }
+        ]
+      },
+      "InstallType": {
+        "description": "Install type code sd|nand",
+        "enum": [
+          "sd",
+          "nand"
+        ],
+        "type": "string"
+      },
+      "Layout": {
+        "properties": {
+          "lg": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "md": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "sm": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "xs": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "xxs": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": [
+              "object",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "Locale": {
+        "enum": [
+          "ru",
+          "en",
+          "fa",
+          "ua",
+          "zh",
+          "pt",
+          "ka"
+        ],
+        "type": "string"
+      },
+      "LocateMinerStatus": {
+        "properties": {
+          "is_enabled": {
+            "description": "Locate miner on/off",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "is_enabled"
+        ],
+        "type": "object"
+      },
+      "LogType": {
+        "description": "Log type name, `*` for all log types",
+        "enum": [
+          "status",
+          "miner",
+          "autotune",
+          "pool",
+          "hwscan",
+          "system",
+          "messages",
+          "api",
+          "*"
+        ],
+        "type": "string"
+      },
+      "MetricAnnotation": {
+        "properties": {
+          "board_id": {
+            "format": "int32",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "type": {
+            "$ref": "#/components/schemas/MinerEvent"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "MetricsData": {
+        "properties": {
+          "chip_max_temp": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "fan_duty": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "hashrate": {
+            "format": "double",
+            "type": "number"
+          },
+          "pcb_max_temp": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "power_consumption": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "hashrate",
+          "pcb_max_temp",
+          "chip_max_temp",
+          "fan_duty",
+          "power_consumption"
+        ],
+        "type": "object"
+      },
+      "MetricsReply": {
+        "properties": {
+          "annotations": {
+            "items": {
+              "$ref": "#/components/schemas/TimeRecord_MetricAnnotation"
+            },
+            "type": "array"
+          },
+          "metrics": {
+            "items": {
+              "$ref": "#/components/schemas/TimeRecord_MetricsData"
+            },
+            "type": "array"
+          },
+          "timezone": {
+            "$ref": "#/components/schemas/Timezone"
+          }
+        },
+        "required": [
+          "timezone",
+          "metrics",
+          "annotations"
+        ],
+        "type": "object"
+      },
+      "MinerConfigRaw": {
+        "properties": {
+          "cooling": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/CoolingSettingsRaw"
+              }
+            ]
+          },
+          "misc": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/AdvancedSettingsRaw"
+              }
+            ]
+          },
+          "overclock": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/OverclockSettingsRaw"
+              }
+            ]
+          },
+          "pools": {
+            "items": false,
+            "prefixItems": [
+              {
+                "properties": {
+                  "pass": {
+                    "type": "string"
+                  },
+                  "url": {
+                    "type": "string"
+                  },
+                  "user": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "url",
+                  "user",
+                  "pass"
+                ],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "pass": {
+                    "type": "string"
+                  },
+                  "url": {
+                    "type": "string"
+                  },
+                  "user": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "url",
+                  "user",
+                  "pass"
+                ],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "pass": {
+                    "type": "string"
+                  },
+                  "url": {
+                    "type": "string"
+                  },
+                  "user": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "url",
+                  "user",
+                  "pass"
+                ],
+                "type": "object"
+              }
+            ],
+            "type": [
+              "array",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "MinerEvent": {
+        "enum": [
+          "start",
+          "stop",
+          "restart",
+          "reboot",
+          "overheat",
+          "disable_board",
+          "enable_board",
+          "fw_update"
+        ],
+        "type": "string"
+      },
+      "MinerFanMinCount": {
+        "properties": {
+          "default": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "max": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "min": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "min",
+          "max",
+          "default"
+        ],
+        "type": "object"
+      },
+      "MinerModelInfo": {
+        "properties": {
+          "algorithm": {
+            "$ref": "#/components/schemas/MiningAlgorithm"
+          },
+          "chain": {
+            "$ref": "#/components/schemas/ModelInfoBoard"
+          },
+          "cooling": {
+            "$ref": "#/components/schemas/CoolingConsts"
+          },
+          "full_name": {
+            "description": "Pretty miner name",
+            "type": "string"
+          },
+          "hr_measure": {
+            "$ref": "#/components/schemas/HrMeasure"
+          },
+          "install_type": {
+            "$ref": "#/components/schemas/InstallType"
+          },
+          "model": {
+            "description": "Miner model code",
+            "type": "string"
+          },
+          "overclock": {
+            "$ref": "#/components/schemas/Overclock"
+          },
+          "platform": {
+            "$ref": "#/components/schemas/Platform"
+          },
+          "serial": {
+            "type": "string"
+          },
+          "series": {
+            "$ref": "#/components/schemas/Series"
+          }
+        },
+        "required": [
+          "full_name",
+          "model",
+          "algorithm",
+          "series",
+          "platform",
+          "install_type",
+          "hr_measure",
+          "serial",
+          "chain",
+          "cooling",
+          "overclock"
+        ],
+        "type": "object"
+      },
+      "MinerState": {
+        "enum": [
+          "mining",
+          "initializing",
+          "starting",
+          "auto-tuning",
+          "restarting",
+          "shutting-down",
+          "stopped",
+          "failure"
+        ],
+        "type": "string"
+      },
+      "MinerStatus": {
+        "properties": {
+          "description": {
+            "description": "Optional. Description if status is failure",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "failure_code": {
+            "format": "int32",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "miner_state": {
+            "$ref": "#/components/schemas/MinerState"
+          },
+          "miner_state_time": {
+            "description": "Time spent in the current state.\nFor now implemented for `mining` state only.",
+            "format": "int64",
+            "type": "integer"
+          },
+          "throttled": {
+            "format": "int32",
+            "maximum": 100,
+            "minimum": 20,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "miner_state",
+          "throttled",
+          "miner_state_time"
+        ],
+        "type": "object"
+      },
+      "MiningAlgorithm": {
+        "enum": [
+          "sha256d",
+          "scrypt"
+        ],
+        "type": "string"
+      },
+      "ModeRaw": {
+        "oneOf": [
+          {
+            "properties": {
+              "name": {
+                "enum": [
+                  "auto"
+                ],
+                "type": "string"
+              },
+              "param": {
+                "format": "int32",
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "param",
+              "name"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "name": {
+                "enum": [
+                  "manual"
+                ],
+                "type": "string"
+              },
+              "param": {
+                "format": "int32",
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "param",
+              "name"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "name": {
+                "enum": [
+                  "immers"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "ModelInfoBoard": {
+        "properties": {
+          "chips_per_chain": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "chips_per_domain": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "num_chains": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "topology": {
+            "$ref": "#/components/schemas/Topology"
+          }
+        },
+        "required": [
+          "chips_per_chain",
+          "chips_per_domain",
+          "num_chains",
+          "topology"
+        ],
+        "type": "object"
+      },
+      "NetworkConfFile": {
+        "properties": {
+          "dhcp": {
+            "type": "boolean"
+          },
+          "dnsservers": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "gateway": {
+            "type": "string"
+          },
+          "hostname": {
+            "type": "string"
+          },
+          "ipaddress": {
+            "type": "string"
+          },
+          "netmask": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "hostname",
+          "dhcp",
+          "ipaddress",
+          "netmask",
+          "gateway",
+          "dnsservers"
+        ],
+        "type": "object"
+      },
+      "NetworkStatus": {
+        "properties": {
+          "dhcp": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "dns": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "gateway": {
+            "type": "string"
+          },
+          "hostname": {
+            "type": "string"
+          },
+          "ip": {
+            "type": "string"
+          },
+          "mac": {
+            "type": "string"
+          },
+          "netmask": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "mac",
+          "ip",
+          "netmask",
+          "gateway",
+          "dns",
+          "hostname"
+        ],
+        "type": "object"
+      },
+      "NoteKeyValue": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/NoteValue"
+          },
+          {
+            "properties": {
+              "key": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "key"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "NoteValue": {
+        "properties": {
+          "value": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "value"
+        ],
+        "type": "object"
+      },
+      "Overclock": {
+        "properties": {
+          "default_freq": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "default_voltage": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "max_freq": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "max_power_limit": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "max_voltage": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "max_voltage_stock_psu": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "min_freq": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "min_voltage": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "power_metering": {
+            "type": "boolean"
+          },
+          "warn_freq": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "max_voltage",
+          "min_voltage",
+          "default_voltage",
+          "max_freq",
+          "min_freq",
+          "default_freq",
+          "warn_freq",
+          "max_voltage_stock_psu",
+          "power_metering",
+          "max_power_limit"
+        ],
+        "type": "object"
+      },
+      "OverclockSettingsRaw": {
+        "properties": {
+          "chains": {
+            "items": {
+              "$ref": "#/components/schemas/BoardRaw"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "globals": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/GlobalsRaw"
+              }
+            ]
+          },
+          "modded_psu": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "preset": {
+            "description": "Profile name",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "preset_switcher": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/PresetSwitcherRaw"
+              }
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "PasswordChange": {
+        "properties": {
+          "current": {
+            "type": "string"
+          },
+          "pw": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "current",
+          "pw"
+        ],
+        "type": "object"
+      },
+      "PerfSummary": {
+        "properties": {
+          "current_preset": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/CurrentPreset"
+              }
+            ]
+          },
+          "preset_switcher": {
+            "$ref": "#/components/schemas/PresetSwitcherRaw"
+          }
+        },
+        "required": [
+          "preset_switcher"
+        ],
+        "type": "object"
+      },
+      "Platform": {
+        "description": "Platform type code aml|bb|cv|stm|xil (Amlogic/BeagleBone/Cvitek/STM/Xilix)",
+        "enum": [
+          "aml",
+          "bb",
+          "cv",
+          "stm",
+          "xil"
+        ],
+        "type": "string"
+      },
+      "Pool": {
+        "properties": {
+          "pass": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "user": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "url",
+          "user",
+          "pass"
+        ],
+        "type": "object"
+      },
+      "PoolStats": {
+        "properties": {
+          "accepted": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "asic_boost": {
+            "deprecated": true,
+            "type": "boolean"
+          },
+          "diff": {
+            "type": "string"
+          },
+          "diffa": {
+            "format": "double",
+            "type": "number"
+          },
+          "id": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "ls_diff": {
+            "format": "float",
+            "type": "number"
+          },
+          "ls_time": {
+            "type": "string"
+          },
+          "ping": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "pool_type": {
+            "$ref": "#/components/schemas/PoolType"
+          },
+          "rejected": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "stale": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "status": {
+            "$ref": "#/components/schemas/PoolStatus"
+          },
+          "url": {
+            "type": "string"
+          },
+          "user": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "url",
+          "pool_type",
+          "user",
+          "status",
+          "asic_boost",
+          "diff",
+          "accepted",
+          "rejected",
+          "stale",
+          "ls_diff",
+          "ls_time",
+          "diffa",
+          "ping"
+        ],
+        "type": "object"
+      },
+      "PoolStatus": {
+        "enum": [
+          "offline",
+          "working",
+          "disabled",
+          "active",
+          "rejecting",
+          "unknown"
+        ],
+        "type": "string"
+      },
+      "PoolType": {
+        "enum": [
+          "UserPool",
+          "DevFee",
+          "Refund"
+        ],
+        "type": "string"
+      },
+      "PresetSwitcherRaw": {
+        "description": "PresetSwitcher settings",
+        "properties": {
+          "autochange_top_preset": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "check_time": {
+            "format": "int32",
+            "maximum": 600,
+            "minimum": 60,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "decrease_temp": {
+            "format": "int32",
+            "maximum": 90,
+            "minimum": 25,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "enabled": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "ignore_fan_speed": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "min_preset": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "rise_temp": {
+            "format": "int32",
+            "maximum": 85,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "top_preset": {
+            "description": "Profile name. Max profile that preset_switcher can switch",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "RebootAfter": {
+        "properties": {
+          "after": {
+            "description": "Number of seconds after the system will reboot\nBy default, is 3 seconds",
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "after"
+        ],
+        "type": "object"
+      },
+      "RegionalSettings": {
+        "properties": {
+          "timezone": {
+            "$ref": "#/components/schemas/TimezoneSettings"
+          }
+        },
+        "required": [
+          "timezone"
+        ],
+        "type": "object"
+      },
+      "SaveConfigResult": {
+        "description": "Apply config result",
+        "properties": {
+          "reboot_required": {
+            "description": "Miner restart required to apply",
+            "type": "boolean"
+          },
+          "restart_required": {
+            "description": "Miner restart required to apply config",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "restart_required",
+          "reboot_required"
+        ],
+        "type": "object"
+      },
+      "SchemaBoolEnum": {
+        "enum": [
+          "true",
+          "false"
+        ],
+        "type": "string"
+      },
+      "SchemaFirmwareUpdate": {
+        "properties": {
+          "file": {
+            "format": "binary",
+            "type": "string"
+          },
+          "keep_settings": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/SchemaBoolEnum",
+                "description": "String \"true\" or \"false\""
+              }
+            ]
+          }
+        },
+        "required": [
+          "file"
+        ],
+        "type": "object"
+      },
+      "SchemaSettingsRestore": {
+        "properties": {
+          "file": {
+            "format": "binary",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file"
+        ],
+        "type": "object"
+      },
+      "Series": {
+        "enum": [
+          "l7",
+          "l9",
+          "x19",
+          "x21"
+        ],
+        "type": "string"
+      },
+      "StatusPane": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/MinerStatus"
+          },
+          {
+            "$ref": "#/components/schemas/SaveConfigResult"
+          },
+          {
+            "properties": {
+              "find_miner": {
+                "description": "Flag to switch locate_miner function on target devices. Optional, default `false`",
+                "type": "boolean"
+              },
+              "unlock_timeout": {
+                "format": "int64",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "unlocked": {
+                "description": "Show screen-lock status (checks that  any of auth methods satisfies)",
+                "type": "boolean"
+              },
+              "warranty": {
+                "$ref": "#/components/schemas/Warranty"
+              }
+            },
+            "required": [
+              "find_miner",
+              "unlocked"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "Summary": {
+        "properties": {
+          "miner": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/AntmMinerStats"
+              }
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "SwitchPoolQuery": {
+        "properties": {
+          "pool_id": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "pool_id"
+        ],
+        "type": "object"
+      },
+      "SystemInfo": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/SystemMem"
+          },
+          {
+            "properties": {
+              "file_system_version": {
+                "type": "string"
+              },
+              "miner_name": {
+                "type": "string"
+              },
+              "network_status": {
+                "$ref": "#/components/schemas/NetworkStatus"
+              },
+              "os": {
+                "type": "string"
+              },
+              "uptime": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "os",
+              "miner_name",
+              "file_system_version",
+              "network_status",
+              "uptime"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "SystemMem": {
+        "properties": {
+          "mem_buf": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "mem_buf_percent": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "mem_free": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "mem_free_percent": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "mem_total": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "mem_total",
+          "mem_free",
+          "mem_free_percent",
+          "mem_buf",
+          "mem_buf_percent"
+        ],
+        "type": "object"
+      },
+      "TempRange": {
+        "properties": {
+          "max": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "min": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "min",
+          "max"
+        ],
+        "type": "object"
+      },
+      "TempSensor": {
+        "properties": {
+          "chip_temp": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "pcb_temp": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "status": {
+            "$ref": "#/components/schemas/TempSensorStatus"
+          }
+        },
+        "required": [
+          "status",
+          "pcb_temp",
+          "chip_temp"
+        ],
+        "type": "object"
+      },
+      "TempSensorStatus": {
+        "enum": [
+          "init",
+          "ready",
+          "measure",
+          "error",
+          "unknown"
+        ],
+        "type": "string"
+      },
+      "ThrottleSettings": {
+        "properties": {
+          "percent": {
+            "format": "int32",
+            "maximum": 100,
+            "minimum": 20,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "percent"
+        ],
+        "type": "object"
+      },
+      "TimeRecord_MetricAnnotation": {
+        "properties": {
+          "data": {
+            "properties": {
+              "board_id": {
+                "format": "int32",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "type": {
+                "$ref": "#/components/schemas/MinerEvent"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "type": "object"
+          },
+          "time": {
+            "description": "UNIX time",
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "time",
+          "data"
+        ],
+        "type": "object"
+      },
+      "TimeRecord_MetricsData": {
+        "properties": {
+          "data": {
+            "properties": {
+              "chip_max_temp": {
+                "format": "int32",
+                "type": "integer"
+              },
+              "fan_duty": {
+                "format": "int32",
+                "type": "integer"
+              },
+              "hashrate": {
+                "format": "double",
+                "type": "number"
+              },
+              "pcb_max_temp": {
+                "format": "int32",
+                "type": "integer"
+              },
+              "power_consumption": {
+                "format": "int32",
+                "type": "integer"
+              }
+            },
+            "required": [
+              "hashrate",
+              "pcb_max_temp",
+              "chip_max_temp",
+              "fan_duty",
+              "power_consumption"
+            ],
+            "type": "object"
+          },
+          "time": {
+            "description": "UNIX time",
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "time",
+          "data"
+        ],
+        "type": "object"
+      },
+      "Timezone": {
+        "description": "Current timezone name (code)",
+        "enum": [
+          "GMT+1",
+          "GMT+2",
+          "GMT+3",
+          "GMT+4",
+          "GMT+5",
+          "GMT+6",
+          "GMT+7",
+          "GMT+8",
+          "GMT+9",
+          "GMT+10",
+          "GMT+11",
+          "GMT+12",
+          "GMT",
+          "GMT-1",
+          "GMT-2",
+          "GMT-3",
+          "GMT-4",
+          "GMT-5",
+          "GMT-6",
+          "GMT-7",
+          "GMT-8",
+          "GMT-9",
+          "GMT-10",
+          "GMT-11"
+        ],
+        "type": "string"
+      },
+      "TimezoneSettings": {
+        "properties": {
+          "current": {
+            "$ref": "#/components/schemas/Timezone"
+          }
+        },
+        "required": [
+          "current"
+        ],
+        "type": "object"
+      },
+      "Topology": {
+        "properties": {
+          "chips": {
+            "items": {
+              "items": {
+                "format": "int32",
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "type": "array"
+          },
+          "num_cols": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "num_rows": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "chips",
+          "num_cols",
+          "num_rows"
+        ],
+        "type": "object"
+      },
+      "UiSettings": {
+        "properties": {
+          "consts": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/Consts"
+              }
+            ]
+          },
+          "dark_side_pane": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "disable_animation": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "locale": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/Locale"
+              }
+            ]
+          },
+          "theme": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/UiTheme"
+              }
+            ]
+          },
+          "timezone": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/Timezone"
+              }
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "UiTheme": {
+        "enum": [
+          "light",
+          "dark",
+          "auto"
+        ],
+        "type": "string"
+      },
+      "UnlockScreenBody": {
+        "properties": {
+          "pw": {
+            "description": "Target device(s) password",
+            "type": "string"
+          }
+        },
+        "required": [
+          "pw"
+        ],
+        "type": "object"
+      },
+      "UnlockSuccess": {
+        "properties": {
+          "token": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "token"
+        ],
+        "type": "object"
+      },
+      "ViewConfig": {
+        "properties": {
+          "layout": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/Layout"
+              }
+            ]
+          },
+          "miner": {
+            "$ref": "#/components/schemas/MinerConfigRaw"
+          },
+          "network": {
+            "$ref": "#/components/schemas/NetworkConfFile"
+          },
+          "password": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/PasswordChange"
+              }
+            ]
+          },
+          "regional": {
+            "$ref": "#/components/schemas/RegionalSettings"
+          },
+          "ui": {
+            "$ref": "#/components/schemas/UiSettings"
+          }
+        },
+        "required": [
+          "miner",
+          "ui",
+          "regional",
+          "network"
+        ],
+        "type": "object"
+      },
+      "Warranty": {
+        "enum": [
+          "active",
+          "inactive",
+          "expired",
+          "cancelled",
+          "not_provided"
+        ],
+        "type": "string"
+      },
+      "WarrantyStatus": {
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "warranty": {
+            "$ref": "#/components/schemas/Warranty"
+          }
+        },
+        "required": [
+          "success"
+        ],
+        "type": "object"
+      }
+    },
+    "securitySchemes": {
+      "apikeyAuth": {
+        "in": "header",
+        "name": "x-api-key",
+        "type": "apiKey"
+      },
+      "bearerAuth": {
+        "bearerFormat": "JWT",
+        "scheme": "bearer",
+        "type": "http"
+      }
+    }
+  },
+  "info": {
+    "contact": {
+      "email": "support@anthill.farm",
+      "name": "anthill.farm"
+    },
+    "description": "",
+    "license": {
+      "name": ""
+    },
+    "title": "xminer-api",
+    "version": "0.1.0"
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/activate-warranty": {
+      "post": {
+        "operationId": "warrantyActivate",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WarrantyStatus"
+                }
+              }
+            },
+            "description": "Warranty was successfully activated"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrDescr"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apikeyAuth": []
+          }
+        ],
+        "summary": "Warranty activate",
+        "tags": [
+          "warranty"
+        ]
+      }
+    },
+    "/apikeys": {
+      "get": {
+        "operationId": "apikeysGet",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/ApiKeysJsonItem"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Api key list read successfully"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apikeyAuth": []
+          }
+        ],
+        "summary": "Get apikeys",
+        "tags": [
+          "apikeys"
+        ]
+      },
+      "post": {
+        "operationId": "apikeysAdd",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddApikeyQuery"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AddApiKeyRes"
+                }
+              }
+            },
+            "description": "Api key was added successfully"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrDescr"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apikeyAuth": []
+          }
+        ],
+        "summary": "Add api key",
+        "tags": [
+          "apikeys"
+        ]
+      }
+    },
+    "/apikeys/delete": {
+      "post": {
+        "operationId": "apikeysDelete",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeleteApikeyQuery"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Key deleted successfully"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrDescr"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apikeyAuth": []
+          }
+        ],
+        "summary": "Delete api key",
+        "tags": [
+          "apikeys"
+        ]
+      }
+    },
+    "/auth-check": {
+      "get": {
+        "operationId": "authCheck",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthCheck"
+                }
+              }
+            },
+            "description": "Authorized"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthCheck"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apikeyAuth": []
+          }
+        ],
+        "summary": "Auth Check",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/autotune/presets": {
+      "get": {
+        "operationId": "autotunePresets",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AutotunePresetDto"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Autotune preset list read successfully"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrDescr"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apikeyAuth": []
+          }
+        ],
+        "summary": "Get autotune preset list",
+        "tags": [
+          "autotune"
+        ]
+      }
+    },
+    "/autotune/reset": {
+      "post": {
+        "operationId": "autotuneReset",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AutotuneReset"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Reset list of autotune profiles done successfully"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrDescr"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apikeyAuth": []
+          }
+        ],
+        "summary": "Autotune reset list of profiles",
+        "tags": [
+          "autotune"
+        ]
+      }
+    },
+    "/autotune/reset-all": {
+      "post": {
+        "operationId": "autotuneResetAll",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AutotuneResetAll"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Reset all autotune profiles done successfully"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrDescr"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apikeyAuth": []
+          }
+        ],
+        "summary": "Autotune reset all profiles",
+        "tags": [
+          "autotune"
+        ]
+      }
+    },
+    "/boards": {
+      "get": {
+        "operationId": "getBoards",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AntmBoardChips"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Boards read successfully"
+          }
+        },
+        "summary": "Get miner boards",
+        "tags": [
+          "other"
+        ]
+      }
+    },
+    "/cancel-warranty": {
+      "post": {
+        "operationId": "warrantyCancel",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WarrantyStatus"
+                }
+              }
+            },
+            "description": "Warranty canceled successfully, or was not provided"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrDescr"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apikeyAuth": []
+          }
+        ],
+        "summary": "Warranty cancel",
+        "tags": [
+          "warranty"
+        ]
+      }
+    },
+    "/chains/factory-info": {
+      "get": {
+        "operationId": "getChainsFactoryInfo",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FactoryInfoReply"
+                }
+              }
+            },
+            "description": "Boards factory info read successfully"
+          }
+        },
+        "summary": "Get miner boards factory info",
+        "tags": [
+          "other"
+        ]
+      }
+    },
+    "/find-miner": {
+      "post": {
+        "deprecated": true,
+        "operationId": "findMiner",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "null"
+                    },
+                    {
+                      "$ref": "#/components/schemas/FindMinerStatus"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "Request handled successfully"
+          }
+        },
+        "summary": "Find miner",
+        "tags": [
+          "other"
+        ]
+      }
+    },
+    "/firmware/remove": {
+      "post": {
+        "operationId": "firmwareRemove",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FwRemoveParams"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RebootAfter"
+                }
+              }
+            },
+            "description": "Firmware was successfully removed. System will reboot after"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrDescr"
+                }
+              }
+            },
+            "description": "This model has no 'remove firmware'"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrDescr"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apikeyAuth": []
+          }
+        ],
+        "summary": "Remove firmware and boot from stock",
+        "tags": [
+          "firmware"
+        ]
+      }
+    },
+    "/firmware/update": {
+      "post": {
+        "operationId": "firmwareUpdate",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/SchemaFirmwareUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RebootAfter"
+                }
+              }
+            },
+            "description": "Firmware update successfully. System will reboot after"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrDescr"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apikeyAuth": []
+          }
+        ],
+        "summary": "Update firmware",
+        "tags": [
+          "firmware"
+        ]
+      }
+    },
+    "/info": {
+      "get": {
+        "operationId": "getInfo",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InfoJson"
+                }
+              }
+            },
+            "description": "Miner Info"
+          }
+        },
+        "summary": "Get miner info",
+        "tags": [
+          "other"
+        ]
+      }
+    },
+    "/layout": {
+      "get": {
+        "operationId": "layout",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "null"
+                    },
+                    {
+                      "$ref": "#/components/schemas/Layout"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "Dashboard elements layout"
+          }
+        },
+        "summary": "Layout",
+        "tags": [
+          "other"
+        ]
+      }
+    },
+    "/locate-miner": {
+      "post": {
+        "operationId": "locateMiner",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LocateMinerStatus"
+                }
+              }
+            },
+            "description": "Request handled successfully"
+          }
+        },
+        "summary": "Locate miner",
+        "tags": [
+          "other"
+        ]
+      }
+    },
+    "/lock": {
+      "post": {
+        "operationId": "lock",
+        "responses": {
+          "200": {
+            "description": "Session dropped"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Lock miner",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/lock/others": {
+      "post": {
+        "operationId": "lock_others",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UnlockScreenBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Other sessions dropped"
+          },
+          "400": {
+            "description": "Wrong password"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrDescr"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Lock other miner sessions",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/logs/{log_type}": {
+      "get": {
+        "operationId": "logsGet",
+        "parameters": [
+          {
+            "description": "Log type name. All logs `*` are not implemented for this route",
+            "in": "path",
+            "name": "log_type",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/LogType"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Log file was read successfully"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrDescr"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "Read log file",
+        "tags": [
+          "logs"
+        ]
+      }
+    },
+    "/logs/{log_type}/clear": {
+      "post": {
+        "operationId": "logsClear",
+        "parameters": [
+          {
+            "description": "Log type",
+            "in": "path",
+            "name": "log_type",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/LogType"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Logs was cleared successfully"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrDescr"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apikeyAuth": []
+          }
+        ],
+        "summary": "Clear logs",
+        "tags": [
+          "logs"
+        ]
+      }
+    },
+    "/metrics": {
+      "get": {
+        "operationId": "metrics",
+        "parameters": [
+          {
+            "description": "Amount of seconds until now. Max is 3 days (3 * 24 * 60 * 60) Default is 1 day (24 * 60 * 60)",
+            "in": "query",
+            "name": "time_slice",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Resample step in seconds to count average, default is 15 min (15 * 60)",
+            "in": "query",
+            "name": "step",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetricsReply"
+                }
+              }
+            },
+            "description": "Config saved successfully"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrDescr"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "Get metrics",
+        "tags": [
+          "metrics"
+        ]
+      }
+    },
+    "/mining/pause": {
+      "post": {
+        "operationId": "miningPause",
+        "responses": {
+          "200": {
+            "description": "Mining paused"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrDescr"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apikeyAuth": []
+          }
+        ],
+        "summary": "Mining pause",
+        "tags": [
+          "mining"
+        ]
+      }
+    },
+    "/mining/restart": {
+      "post": {
+        "operationId": "miningRestart",
+        "responses": {
+          "200": {
+            "description": "Mining restart"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrDescr"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apikeyAuth": []
+          }
+        ],
+        "summary": "Mining restart",
+        "tags": [
+          "mining"
+        ]
+      }
+    },
+    "/mining/resume": {
+      "post": {
+        "operationId": "miningResume",
+        "responses": {
+          "200": {
+            "description": "Mining resumed"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrDescr"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apikeyAuth": []
+          }
+        ],
+        "summary": "Mining resume",
+        "tags": [
+          "mining"
+        ]
+      }
+    },
+    "/mining/start": {
+      "post": {
+        "operationId": "miningStart",
+        "responses": {
+          "200": {
+            "description": "Mining started"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrDescr"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apikeyAuth": []
+          }
+        ],
+        "summary": "Mining start",
+        "tags": [
+          "mining"
+        ]
+      }
+    },
+    "/mining/stop": {
+      "post": {
+        "operationId": "miningStop",
+        "responses": {
+          "200": {
+            "description": "Mining stopped"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrDescr"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apikeyAuth": []
+          }
+        ],
+        "summary": "Mining stop",
+        "tags": [
+          "mining"
+        ]
+      }
+    },
+    "/mining/switch-pool": {
+      "post": {
+        "operationId": "miningSwitchPool",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SwitchPoolQuery"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Pool was switched successfully"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrDescr"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apikeyAuth": []
+          }
+        ],
+        "summary": "Mining switch pool",
+        "tags": [
+          "mining"
+        ]
+      }
+    },
+    "/mining/throttle": {
+      "post": {
+        "operationId": "setThrottleSettings",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ThrottleSettings"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SaveConfigResult"
+                }
+              }
+            },
+            "description": "Throttle settings updated successfully"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrDescr"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apikeyAuth": []
+          }
+        ],
+        "summary": "Update throttle settings",
+        "tags": [
+          "mining"
+        ]
+      }
+    },
+    "/model": {
+      "get": {
+        "operationId": "getModel",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MinerModelInfo"
+                }
+              }
+            },
+            "description": "Miner model Info"
+          }
+        },
+        "summary": "Get miner model info",
+        "tags": [
+          "other"
+        ]
+      }
+    },
+    "/notes": {
+      "get": {
+        "operationId": "readNotes",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "propertyNames": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Notes read successfully"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrDescr"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "Read all notes",
+        "tags": [
+          "notes"
+        ]
+      },
+      "post": {
+        "operationId": "createNote",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NoteKeyValue"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Note add successfully"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrDescr"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrDescr"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "507": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrDescr"
+                }
+              }
+            },
+            "description": "Insufficient Storage"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apikeyAuth": []
+          }
+        ],
+        "summary": "Add note",
+        "tags": [
+          "notes"
+        ]
+      }
+    },
+    "/notes/{note}": {
+      "delete": {
+        "operationId": "deleteNote",
+        "parameters": [
+          {
+            "description": "Note key",
+            "in": "path",
+            "name": "note",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Note delete successfully"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrDescr"
+                }
+              }
+            },
+            "description": "Not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrDescr"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apikeyAuth": []
+          }
+        ],
+        "summary": "Delete note",
+        "tags": [
+          "notes"
+        ]
+      },
+      "get": {
+        "operationId": "readNote",
+        "parameters": [
+          {
+            "description": "Note key",
+            "in": "path",
+            "name": "note",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NoteValue"
+                }
+              }
+            },
+            "description": "Notes read successfully"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrDescr"
+                }
+              }
+            },
+            "description": "Not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrDescr"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "Get one note json",
+        "tags": [
+          "notes"
+        ]
+      },
+      "put": {
+        "operationId": "updateNote",
+        "parameters": [
+          {
+            "description": "Note key",
+            "in": "path",
+            "name": "note",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NoteValue"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Notes add successfully"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrDescr"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apikeyAuth": []
+          }
+        ],
+        "summary": "Update notes",
+        "tags": [
+          "notes"
+        ]
+      }
+    },
+    "/perf-summary": {
+      "get": {
+        "operationId": "perfSummary",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PerfSummary"
+                }
+              }
+            },
+            "description": "Chips read successfully"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrDescr"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "Summary",
+        "tags": [
+          "other"
+        ]
+      }
+    },
+    "/settings": {
+      "get": {
+        "operationId": "settingsGet",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ViewConfig"
+                }
+              }
+            },
+            "description": "Config read successfully"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrDescr"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "apikeyAuth": []
+          }
+        ],
+        "summary": "Get all miner settings",
+        "tags": [
+          "settings"
+        ]
+      },
+      "post": {
+        "operationId": "settingsSave",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InputConfig"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SaveConfigResult"
+                }
+              }
+            },
+            "description": "Config saved successfully"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrDescr"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apikeyAuth": []
+          }
+        ],
+        "summary": "Save miner settings",
+        "tags": [
+          "settings"
+        ]
+      }
+    },
+    "/settings/backup": {
+      "post": {
+        "operationId": "settingsBackup",
+        "responses": {
+          "200": {
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "items": {
+                    "format": "int32",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Backup binary"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apikeyAuth": []
+          }
+        ],
+        "summary": "Settings backup",
+        "tags": [
+          "settings"
+        ]
+      }
+    },
+    "/settings/factory-reset": {
+      "post": {
+        "operationId": "settingsFactoryReset",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RebootAfter"
+                }
+              }
+            },
+            "description": "Settings factory reset done successfully. System will reboot after"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrDescr"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apikeyAuth": []
+          }
+        ],
+        "summary": "Settings factory reset",
+        "tags": [
+          "settings"
+        ]
+      }
+    },
+    "/settings/restore": {
+      "post": {
+        "operationId": "settingsRestore",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/SchemaSettingsRestore"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RebootAfter"
+                }
+              }
+            },
+            "description": "Firmware restored successfully. System will reboot after"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Miner have warranty. Cancel warranty first"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrDescr"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apikeyAuth": []
+          }
+        ],
+        "summary": "Settings restore",
+        "tags": [
+          "settings"
+        ]
+      }
+    },
+    "/status": {
+      "get": {
+        "operationId": "status",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusPane"
+                }
+              }
+            },
+            "description": "success"
+          }
+        },
+        "summary": "Get status",
+        "tags": [
+          "other"
+        ]
+      }
+    },
+    "/summary": {
+      "get": {
+        "operationId": "summary",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Summary"
+                }
+              }
+            },
+            "description": "Summary read successfully"
+          }
+        },
+        "security": [
+          {},
+          {
+            "bearerAuth": []
+          },
+          {
+            "apikeyAuth": []
+          }
+        ],
+        "summary": "Summary",
+        "tags": [
+          "other"
+        ]
+      }
+    },
+    "/system/reboot": {
+      "post": {
+        "operationId": "systemReboot",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RebootAfter"
+                }
+              }
+            },
+            "description": "System reboot after"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apikeyAuth": []
+          }
+        ],
+        "summary": "System reboot",
+        "tags": [
+          "system"
+        ]
+      }
+    },
+    "/ui": {
+      "get": {
+        "operationId": "ui",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UiSettings"
+                }
+              }
+            },
+            "description": "Ui read successfully"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrDescr"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "UI",
+        "tags": [
+          "other"
+        ]
+      }
+    },
+    "/unlock": {
+      "post": {
+        "operationId": "unlock",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UnlockScreenBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnlockSuccess"
+                }
+              }
+            },
+            "description": "Authorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthCheck"
+                }
+              }
+            },
+            "description": "Wrong password"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthCheck"
+                }
+              }
+            },
+            "description": "Too many requests"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrDescr"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "Auth Check",
+        "tags": [
+          "auth"
+        ]
+      }
+    }
+  },
+  "servers": [
+    {
+      "description": "Current miner API",
+      "url": "/api/v1"
+    }
+  ]
+}


### PR DESCRIPTION
Adds the AnthillOS/VNish **1.3.4** OpenAPI schema (pulled from the miner's own `/docs/api-doc.json` on an S19 Pro Hydro, firmware build 2026-06-15), same format as the existing `v1.2.6`/`v1.2.7`.

Notably it documents **`POST /mining/throttle`** (`ThrottleSettings.percent`, 20–100) — new since 1.2.x and what the asic-rs VNish backend uses for throttle control (cf. #289).