### PR TITLE
fix(vnish): read 1.3.x thermal limits from /settings, not /summary

### DIFF
--- a/asic-rs-firmwares/vnish/src/backends/v1_3_0/mod.rs
+++ b/asic-rs-firmwares/vnish/src/backends/v1_3_0/mod.rs
@@ -66,15 +66,35 @@ impl GetConfigsLocations for VnishV130 {
             command: "summary",
             parameters: None,
         };
+        // VNish 1.3.x slimmed down the public `/summary`: `miner.misc` (which
+        // holds `restart_temp`) is gone, and `miner.cooling` no longer carries
+        // `min_startup_water_temp`. Both still live in the authenticated
+        // `/settings` endpoint, which is the canonical config source. Read the
+        // thermal config from `/settings` and keep `/summary` as a fallback so
+        // any firmware that still exposes the limits there keeps working.
+        const WEB_SETTINGS: MinerCommand = MinerCommand::WebAPI {
+            command: "settings",
+            parameters: None,
+        };
         match data_field {
-            ConfigField::Temperature => vec![(
-                WEB_SUMMARY,
-                ConfigExtractor {
-                    func: get_by_pointer,
-                    key: Some("/miner"),
-                    tag: None,
-                },
-            )],
+            ConfigField::Temperature => vec![
+                (
+                    WEB_SETTINGS,
+                    ConfigExtractor {
+                        func: get_by_pointer,
+                        key: Some("/miner"),
+                        tag: None,
+                    },
+                ),
+                (
+                    WEB_SUMMARY,
+                    ConfigExtractor {
+                        func: get_by_pointer,
+                        key: Some("/miner"),
+                        tag: None,
+                    },
+                ),
+            ],
             _ => vec![],
         }
     }
@@ -998,10 +1018,12 @@ impl SupportsTemperatureConfig for VnishV130 {
         true
     }
 
-    /// VNish reports configured thermal limits in `/summary`: the minimum
-    /// startup water temperature and the self-protection restart temperature.
-    /// `hot` is not exposed via `/summary` (left `None` = not reported, not
-    /// "no limit").
+    /// VNish reports the configured thermal limits in `/settings`
+    /// (`miner.misc.restart_temp` and `miner.cooling.min_startup_water_temp`):
+    /// the minimum startup water temperature and the self-protection restart
+    /// temperature. On 1.3.x these are no longer present in `/summary`, so the
+    /// config location reads `/settings` (see `get_configs_locations`). `hot` is
+    /// not reported by the firmware (left `None` = not reported, not "no limit").
     fn parse_temperature_config(
         &self,
         data: &HashMap<ConfigField, Value>,


### PR DESCRIPTION
## What

The VNish `v1_3_0` backend read its `TemperatureConfig` (`ConfigField::Temperature`) from `/summary`, pointing at `/miner`. On VNish 1.3.x the public `/summary` was slimmed down — `miner.misc` (which holds `restart_temp`) is gone, and `miner.cooling` no longer carries `min_startup_water_temp`. As a result both `danger` (self-protection restart temperature) and `minimum` (min startup water temp) come back `None` on 1.3.x firmware.

This PR reads the thermal config from the authenticated `/settings` endpoint — the canonical config source, where both values still live — and keeps `/summary` as a fallback. The misleading doc comment on `parse_temperature_config` is corrected.

## Why this slipped through

Apologies — this one is on me. The thermal-limits feature was originally written to read from `/settings` (correct), but somewhere in the churn of porting it across the 0.6.x → 0.7.0 → preset/throttle/v1.3.0-split branches, the source got "simplified" back to `/summary` and the supporting comment followed. Maintenance across all those parallel branches clearly slipped here. I caught it while testing the current `0.7.1` against a live miner whose firmware had since moved to 1.3.4.

## Scope / blast radius

I went through every `/summary`-sourced field in the `v1_3_0` backend against a live 1.3.4 `/summary`:

| Field | Source pointer | 1.3.4 `/summary` | Status |
|---|---|---|---|
| Temperature (restart/min-startup) | `/miner/misc`, `/miner/cooling/min_startup_water_temp` | **gone** | **fixed here** |
| Hashrate, ExpectedHashrate, Wattage, Fans, Hashboards, Pools, Fluid/OutletFluid temps, Messages, TuningPercent | various | still present | OK |

`miner.overclock` was also dropped from 1.3.x `/summary`, but the backend already sources preset / power-limit data from the authenticated endpoints (`/settings`, `/autotune/presets`), so nothing else is affected. The thermal config is the only casualty.

## Verification

- Live VNish 1.3.4 (S19 Pro Hydro): `GET /api/v1/summary` has no `miner.misc`; authenticated `GET /api/v1/settings` returns `miner.misc.restart_temp = 78` and `miner.cooling.min_startup_water_temp = 17`.
- `v1_3_0` only serves firmware `>= 1.3.0` (per the backend version routing), so `/settings` is always the right source for this backend; the `/summary` fallback is purely defensive.
- CI: tests green on the branch.

Routing note: `/settings` is already used by `set_power_limit` in this backend, so the authenticated path is exercised and unchanged.