### PR TITLE
Derive EPic coin from model hash algorithm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,6 +228,7 @@ dependencies = [
  "asic-rs-core",
  "asic-rs-makes-antminer",
  "asic-rs-makes-epic",
+ "asic-rs-makes-volcminer",
  "asic-rs-makes-whatsminer",
  "async-trait",
  "macaddr",

--- a/asic-rs-core/src/traits/model.rs
+++ b/asic-rs-core/src/traits/model.rs
@@ -4,11 +4,17 @@ use std::{
     str::FromStr,
 };
 
-use crate::{data::device::MinerHardware, errors::ModelSelectionError};
+use crate::{
+    data::device::{HashAlgorithm, MinerHardware},
+    errors::ModelSelectionError,
+};
 
 pub trait MinerModel: Display + Into<MinerHardware> + Clone + Any {
     fn make_name(&self) -> String;
     fn is_known(&self) -> bool;
+    fn hash_algorithm(&self) -> HashAlgorithm {
+        HashAlgorithm::SHA256
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/asic-rs-firmwares/epic/Cargo.toml
+++ b/asic-rs-firmwares/epic/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 asic-rs-core.workspace = true
 asic-rs-makes-antminer.workspace = true
 asic-rs-makes-epic.workspace = true
+asic-rs-makes-volcminer.workspace = true
 asic-rs-makes-whatsminer.workspace = true
 
 async-trait.workspace = true

--- a/asic-rs-firmwares/epic/src/backends/v1/mod.rs
+++ b/asic-rs-firmwares/epic/src/backends/v1/mod.rs
@@ -49,10 +49,18 @@ pub struct PowerPlayV1 {
 impl PowerPlayV1 {
     pub fn new(ip: IpAddr, model: impl MinerModel) -> Self {
         let auth = Self::default_auth();
+        let hash_algorithm = model.hash_algorithm();
         PowerPlayV1 {
             ip,
             web: PowerPlayWebAPI::new(ip, 4028, auth),
-            device_info: DeviceInfo::new(model, EPicFirmware::default(), HashAlgorithm::SHA256),
+            device_info: DeviceInfo::new(model, EPicFirmware::default(), hash_algorithm),
+        }
+    }
+
+    fn coin_type_for_hash_algorithm(hash_algorithm: HashAlgorithm) -> &'static str {
+        match hash_algorithm {
+            HashAlgorithm::Scrypt => "LTC",
+            _ => "BTC",
         }
     }
 
@@ -1196,7 +1204,7 @@ impl SupportsPoolsConfig for PowerPlayV1 {
         anyhow::ensure!(!groups.is_empty(), "No non-empty pool groups provided");
         anyhow::ensure!(groups.len() <= 3, "ePIC supports up to 3 pool groups");
 
-        let coin = "BTC";
+        let coin = Self::coin_type_for_hash_algorithm(self.device_info.algo);
         let unique_id_enabled = false;
 
         if let [group] = groups.as_slice() {
@@ -1582,7 +1590,10 @@ mod tests {
     use std::sync::Arc;
 
     use anyhow::{self, Context};
-    use asic_rs_core::test::{api::MockAPIClient, util::get_miner};
+    use asic_rs_core::{
+        test::{api::MockAPIClient, util::get_miner},
+        traits::firmware::MinerFirmware,
+    };
     use asic_rs_makes_antminer::models::AntMinerModel;
 
     use super::*;
@@ -1876,6 +1887,60 @@ mod tests {
         assert_eq!(miner_data.ip, ip);
         assert!(miner_data.timestamp > 0);
         assert!(!miner_data.schema_version.is_empty());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[ignore = "requires live miner and writes pool config; set MINER_IP"]
+    async fn set_pools_config_live_test_increment_worker() -> anyhow::Result<()> {
+        let ip_str = std::env::var("MINER_IP").context("MINER_IP is not set")?;
+        let ip =
+            IpAddr::from_str(&ip_str).with_context(|| format!("invalid MINER_IP: {ip_str}"))?;
+
+        let model = EPicFirmware::get_model(ip).await?;
+        let miner = PowerPlayV1::new(ip, model);
+
+        let current = miner.get_pools_config().await?;
+        println!("current pools {}", serde_json::to_string_pretty(&current)?);
+        anyhow::ensure!(!current.is_empty(), "miner has no pool groups configured");
+
+        let target = current
+            .iter()
+            .map(|group| PoolGroupConfig {
+                name: group.name.clone(),
+                quota: group.quota,
+                pools: group
+                    .pools
+                    .iter()
+                    .map(|pool| PoolConfig {
+                        url: pool.url.clone(),
+                        username: format!("{}1", pool.username),
+                        password: pool.password.clone(),
+                    })
+                    .collect(),
+            })
+            .collect::<Vec<_>>();
+
+        assert!(miner.set_pools_config(target.clone()).await?);
+
+        let updated = miner.get_pools_config().await?;
+        println!("updated pools {}", serde_json::to_string_pretty(&updated)?);
+
+        for expected in target.iter().flat_map(|group| group.pools.iter()) {
+            let updated_pool = updated
+                .iter()
+                .flat_map(|group| group.pools.iter())
+                .find(|pool| pool.url == expected.url && pool.username == expected.username)
+                .with_context(|| {
+                    format!(
+                        "target pool config was not written: {} {}",
+                        expected.url, expected.username
+                    )
+                })?;
+
+            assert_eq!(updated_pool.password, expected.password);
+        }
 
         Ok(())
     }

--- a/asic-rs-firmwares/epic/src/firmware.rs
+++ b/asic-rs-firmwares/epic/src/firmware.rs
@@ -1,7 +1,10 @@
 use std::{fmt, fmt::Display, net::IpAddr};
 
 use asic_rs_core::{
-    data::{command::MinerCommand, device::MinerHardware},
+    data::{
+        command::MinerCommand,
+        device::{HashAlgorithm, MinerHardware},
+    },
     discovery::HTTP_WEB_ROOT,
     errors::ModelSelectionError,
     traits::{
@@ -17,12 +20,14 @@ use asic_rs_core::{
 };
 use asic_rs_makes_antminer::{make::AntMinerMake, models::AntMinerModel};
 use asic_rs_makes_epic::{make::EPicMake, models::EPicModel};
+use asic_rs_makes_volcminer::{make::VolcMinerMake, models::VolcMinerModel};
 use asic_rs_makes_whatsminer::{make::WhatsMinerMake, models::WhatsMinerModel};
 use async_trait::async_trait;
 
 #[derive(Clone)]
 pub enum EPicCompatibleModel {
     AntMiner(AntMinerModel),
+    VolcMiner(VolcMinerModel),
     WhatsMiner(WhatsMinerModel),
     EPic(EPicModel),
     Unknown(UnknownMinerModel),
@@ -32,6 +37,7 @@ impl Display for EPicCompatibleModel {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::AntMiner(m) => m.fmt(f),
+            Self::VolcMiner(m) => m.fmt(f),
             Self::WhatsMiner(m) => m.fmt(f),
             Self::EPic(m) => m.fmt(f),
             Self::Unknown(m) => m.fmt(f),
@@ -43,6 +49,7 @@ impl From<EPicCompatibleModel> for MinerHardware {
     fn from(model: EPicCompatibleModel) -> Self {
         match model {
             EPicCompatibleModel::AntMiner(m) => m.into(),
+            EPicCompatibleModel::VolcMiner(m) => m.into(),
             EPicCompatibleModel::WhatsMiner(m) => m.into(),
             EPicCompatibleModel::EPic(m) => m.into(),
             EPicCompatibleModel::Unknown(m) => m.into(),
@@ -54,6 +61,7 @@ impl MinerModel for EPicCompatibleModel {
     fn make_name(&self) -> String {
         match self {
             Self::AntMiner(m) => m.make_name(),
+            Self::VolcMiner(m) => m.make_name(),
             Self::WhatsMiner(m) => m.make_name(),
             Self::EPic(m) => m.make_name(),
             Self::Unknown(m) => m.make_name(),
@@ -62,9 +70,20 @@ impl MinerModel for EPicCompatibleModel {
     fn is_known(&self) -> bool {
         match self {
             Self::AntMiner(m) => m.is_known(),
+            Self::VolcMiner(m) => m.is_known(),
             Self::WhatsMiner(m) => m.is_known(),
             Self::EPic(m) => m.is_known(),
             Self::Unknown(m) => m.is_known(),
+        }
+    }
+
+    fn hash_algorithm(&self) -> HashAlgorithm {
+        match self {
+            Self::AntMiner(m) => m.hash_algorithm(),
+            Self::VolcMiner(m) => m.hash_algorithm(),
+            Self::WhatsMiner(m) => m.hash_algorithm(),
+            Self::EPic(m) => m.hash_algorithm(),
+            Self::Unknown(m) => m.hash_algorithm(),
         }
     }
 }
@@ -117,6 +136,12 @@ impl MinerFirmware for EPicFirmware {
         if model_upper.starts_with("ANTMINER") {
             AntMinerMake::parse_model(model_upper.clone())
                 .map(EPicCompatibleModel::AntMiner)
+                .or(Ok(EPicCompatibleModel::Unknown(UnknownMinerModel {
+                    name: model_upper,
+                })))
+        } else if model_upper.starts_with("VOLCMINER") {
+            VolcMinerMake::parse_model(model_upper.clone())
+                .map(EPicCompatibleModel::VolcMiner)
                 .or(Ok(EPicCompatibleModel::Unknown(UnknownMinerModel {
                     name: model_upper,
                 })))

--- a/asic-rs-makes/volcminer/src/models.rs
+++ b/asic-rs-makes/volcminer/src/models.rs
@@ -1,6 +1,8 @@
 use std::str::FromStr;
 
-use asic_rs_core::{errors::ModelSelectionError, traits::model::MinerModel};
+use asic_rs_core::{
+    data::device::HashAlgorithm, errors::ModelSelectionError, traits::model::MinerModel,
+};
 use serde::{Deserialize, Serialize};
 use strum::Display;
 
@@ -28,6 +30,10 @@ impl MinerModel for VolcMinerModel {
 
     fn is_known(&self) -> bool {
         !matches!(self, Self::Unknown(_))
+    }
+
+    fn hash_algorithm(&self) -> HashAlgorithm {
+        HashAlgorithm::Scrypt
     }
 }
 


### PR DESCRIPTION
## Summary
- add MinerModel::hash_algorithm with SHA256 default
- mark VolcMiner models as Scrypt and detect them in EPic PowerPlay
- derive EPic pool coin from the backend device algorithm
- add ignored live test for EPic pool config writes

## Tests
- cargo test -p asic-rs-firmwares-epic
- cargo test -p asic-rs-makes-volcminer