### PR TITLE
fix: map AxeOS VR temp to board, chip temp to chain

### DIFF
--- a/asic-rs-firmwares/bitaxe/src/backends/v2_0_0/mod.rs
+++ b/asic-rs-firmwares/bitaxe/src/backends/v2_0_0/mod.rs
@@ -280,12 +280,24 @@ impl GetHashboards for Bitaxe200 {
                 }
                 .as_unit(HashRateUnit::default())
             });
+        // `vrTemp` is the VR/board sensor; `temp` is the ASIC chip sensor.
+        let chip_temp = api_data
+            .get("temp")
+            .and_then(|v| v.as_f64())
+            .filter(|t| *t > -50.0)
+            .or_else(|| {
+                chip_data
+                    .and_then(|c| c.get("temp"))
+                    .and_then(|v| v.as_f64())
+                    .filter(|t| *t > -50.0)
+            })
+            .map(Temperature::from_celsius);
         board.board_temperature = api_data
             .get("vrTemp")
             .and_then(|v| v.as_f64())
             .map(Temperature::from_celsius);
-        board.inlet_chip_temperature = board.board_temperature;
-        board.outlet_chip_temperature = board.board_temperature;
+        board.inlet_chip_temperature = chip_temp;
+        board.outlet_chip_temperature = chip_temp;
         board.working_chips = api_data
             .get("asicCount")
             .and_then(|v| v.as_u64())
@@ -298,13 +310,10 @@ impl GetHashboards for Bitaxe200 {
             .get("frequency")
             .and_then(|v| v.as_f64())
             .map(Frequency::from_megahertz);
-        if let Some(chip_data) = chip_data {
+        if chip_data.is_some() {
             board.chips = vec![ChipData {
                 position: 0,
-                temperature: chip_data
-                    .get("temp")
-                    .and_then(|v| v.as_f64())
-                    .map(Temperature::from_celsius),
+                temperature: chip_temp,
                 voltage: board.voltage,
                 frequency: board.frequency,
                 tuned: Some(true),
@@ -608,6 +617,24 @@ mod tests {
         let hashboards_without_chips = miner.parse_hashboards(&data);
         assert!(hashboards_without_chips[0].chips.is_empty());
         assert_eq!(hashboards_without_chips[0].working_chips, Some(1));
+        assert_eq!(
+            hashboards_without_chips[0]
+                .board_temperature
+                .map(|t| t.as_celsius()),
+            Some(78.0)
+        );
+        assert_eq!(
+            hashboards_without_chips[0]
+                .inlet_chip_temperature
+                .map(|t| t.as_celsius()),
+            Some(59.875)
+        );
+        assert_eq!(
+            hashboards_without_chips[0]
+                .outlet_chip_temperature
+                .map(|t| t.as_celsius()),
+            Some(59.875)
+        );
 
         let mut collector = DataCollector::new_with_client(&miner, &mock_api);
         let data = collector
@@ -622,6 +649,12 @@ mod tests {
         assert_eq!(
             hashboards_without_chips[0].working_chips,
             hashboards_with_chips[0].working_chips
+        );
+        assert_eq!(
+            hashboards_with_chips[0].chips[0]
+                .temperature
+                .map(|t| t.as_celsius()),
+            Some(59.875)
         );
 
         let mut collector = DataCollector::new_with_client(&miner, &mock_api);

--- a/asic-rs-firmwares/bitaxe/src/backends/v2_9_0/mod.rs
+++ b/asic-rs-firmwares/bitaxe/src/backends/v2_9_0/mod.rs
@@ -282,12 +282,24 @@ impl GetHashboards for Bitaxe290 {
                 }
                 .as_unit(HashRateUnit::default())
             });
+        // `vrTemp` is the VR/board sensor; `temp` is the ASIC chip sensor.
+        let chip_temp = api_data
+            .get("temp")
+            .and_then(|v| v.as_f64())
+            .filter(|t| *t > -50.0)
+            .or_else(|| {
+                chip_data
+                    .and_then(|c| c.get("temp"))
+                    .and_then(|v| v.as_f64())
+                    .filter(|t| *t > -50.0)
+            })
+            .map(Temperature::from_celsius);
         board.board_temperature = api_data
             .get("vrTemp")
             .and_then(|v| v.as_f64())
             .map(Temperature::from_celsius);
-        board.inlet_chip_temperature = board.board_temperature;
-        board.outlet_chip_temperature = board.board_temperature;
+        board.inlet_chip_temperature = chip_temp;
+        board.outlet_chip_temperature = chip_temp;
         board.working_chips = api_data
             .get("asicCount")
             .and_then(|v| v.as_u64())
@@ -300,13 +312,10 @@ impl GetHashboards for Bitaxe290 {
             .get("frequency")
             .and_then(|v| v.as_f64())
             .map(Frequency::from_megahertz);
-        if let Some(chip_data) = chip_data {
+        if chip_data.is_some() {
             board.chips = vec![ChipData {
                 position: 0,
-                temperature: chip_data
-                    .get("temp")
-                    .and_then(|v| v.as_f64())
-                    .map(Temperature::from_celsius),
+                temperature: chip_temp,
                 voltage: board.voltage,
                 frequency: board.frequency,
                 tuned: Some(true),

--- a/asic-rs-firmwares/bitaxe/src/test/json/v2_0_0/system_info.json
+++ b/asic-rs-firmwares/bitaxe/src/test/json/v2_0_0/system_info.json
@@ -34,10 +34,10 @@
   "stratumPort": 3333,
   "stratumURL": "btc.example.pool",
   "stratumUser": "asic-rs.test",
-  "temp": 27,
+  "temp": 59.875,
   "uptimeSeconds": 4,
   "version": "v2.4.5-3-gb5d1e36-dirty",
   "voltage": 5175,
-  "vrTemp": 0,
+  "vrTemp": 78,
   "wifiStatus": "Connected!"
 }

--- a/asic-rs-firmwares/nerdaxe/src/backends/v1/mod.rs
+++ b/asic-rs-firmwares/nerdaxe/src/backends/v1/mod.rs
@@ -264,12 +264,24 @@ impl GetHashboards for NerdAxeV1 {
             }
             .as_unit(HashRateUnit::default())
         });
+        // `vrTemp` is the VR/board sensor; `temp` is the ASIC chip sensor.
+        let chip_temp = api_data
+            .get("temp")
+            .and_then(|v| v.as_f64())
+            .filter(|t| *t > -50.0)
+            .or_else(|| {
+                chip_data
+                    .and_then(|c| c.get("temp"))
+                    .and_then(|v| v.as_f64())
+                    .filter(|t| *t > -50.0)
+            })
+            .map(Temperature::from_celsius);
         board.board_temperature = api_data
             .get("vrTemp")
             .and_then(|v| v.as_f64())
             .map(Temperature::from_celsius);
-        board.inlet_chip_temperature = board.board_temperature;
-        board.outlet_chip_temperature = board.board_temperature;
+        board.inlet_chip_temperature = chip_temp;
+        board.outlet_chip_temperature = chip_temp;
         board.working_chips = api_data
             .get("asicCount")
             .and_then(|v| v.as_u64())
@@ -295,13 +307,10 @@ impl GetHashboards for NerdAxeV1 {
                 }
                 .as_unit(HashRateUnit::default())
             });
-        if let Some(chip_data) = chip_data {
+        if chip_data.is_some() {
             board.chips = vec![ChipData {
                 position: 0,
-                temperature: chip_data
-                    .get("temp")
-                    .and_then(|v| v.as_f64())
-                    .map(Temperature::from_celsius),
+                temperature: chip_temp,
                 voltage: board.voltage,
                 frequency: board.frequency,
                 tuned: Some(true),


### PR DESCRIPTION
AxeOS exposes distinct sensors on `/api/system/info`: `temp` (ASIC chip) and `vrTemp` (voltage regulator / board). Bitaxe and Nerdaxe backends copied `vrTemp` into inlet/outlet chip temperatures and often left `chips[].temperature` empty by reading `temp` from the config-only `/api/system/asic` payload.

This change is limited to the Bitaxe/Nerdaxe firmware backends:

- Map `vrTemp` → `board_temperature`
- Map `temp` → `inlet_chip_temperature` / `outlet_chip_temperature` and `chips[0].temperature` (preferring live system/info)
- Keep chip rows gated on `DataField::Chips`

No core data structure changes.