### PR TITLE
fix(antminer): read power draw from the `new_api` stats payload

### DIFF
--- a/asic-rs-firmwares/antminer/src/backends/v2020/mod.rs
+++ b/asic-rs-firmwares/antminer/src/backends/v2020/mod.rs
@@ -509,14 +509,37 @@ impl GetDataLocations for AntMinerV2020 {
                     tag: None,
                 },
             )],
-            DataField::Wattage => vec![(
-                RPC_STATS,
-                DataExtractor {
-                    func: get_by_pointer,
-                    key: Some("/STATS/1"),
-                    tag: None,
-                },
-            )],
+            DataField::Wattage => {
+                // Newer stock firmware reports power draw only in the `new_api`
+                // variant of `stats`. That is a different payload to the legacy
+                // one: its `STATS` array holds a single element, so the reading
+                // sits at `/STATS/0` rather than the `/STATS/1` used above.
+                //
+                // Not a `const` because `json!` is not const-evaluable.
+                let rpc_new_stats = MinerCommand::RPC {
+                    command: "stats",
+                    parameters: Some(json!({ "new_api": true })),
+                };
+
+                vec![
+                    (
+                        RPC_STATS,
+                        DataExtractor {
+                            func: get_by_pointer,
+                            key: Some("/STATS/1"),
+                            tag: None,
+                        },
+                    ),
+                    (
+                        rpc_new_stats,
+                        DataExtractor {
+                            func: get_by_pointer,
+                            key: Some("/STATS/0"),
+                            tag: None,
+                        },
+                    ),
+                ]
+            }
             DataField::SerialNumber => vec![
                 (
                     WEB_SYSTEM_INFO,
@@ -835,6 +858,9 @@ impl GetWattage for AntMinerV2020 {
             if let Some(power) = stats_data
                 .get("power")
                 .or_else(|| stats_data.get("Power"))
+                // Same firmware version spells this differently per model: the
+                // L9 reports `power`, the L11 `watt`.
+                .or_else(|| stats_data.get("watt"))
                 .and_then(|v| v.as_f64())
             {
                 return Some(Power::from_watts(power));

--- a/asic-rs-firmwares/antminer/src/backends/v2020/mod.rs
+++ b/asic-rs-firmwares/antminer/src/backends/v2020/mod.rs
@@ -510,11 +510,6 @@ impl GetDataLocations for AntMinerV2020 {
                 },
             )],
             DataField::Wattage => {
-                // Newer stock firmware reports power draw only in the `new_api`
-                // variant of `stats`. That is a different payload to the legacy
-                // one: its `STATS` array holds a single element, so the reading
-                // sits at `/STATS/0` rather than the `/STATS/1` used above.
-                //
                 // Not a `const` because `json!` is not const-evaluable.
                 let rpc_new_stats = MinerCommand::RPC {
                     command: "stats",

--- a/asic-rs-firmwares/antminer/src/backends/v2020/rpc.rs
+++ b/asic-rs-firmwares/antminer/src/backends/v2020/rpc.rs
@@ -10,33 +10,33 @@ use asic_rs_core::{
 use async_trait::async_trait;
 use serde_json::{Value, json};
 
+/// Bitmain's one API extension to the cgminer protocol.
+const NEW_API_FLAG: &str = "new_api";
+
 /// Build the JSON request for a cgminer-style RPC call.
 ///
-/// Bitmain's API extensions — `new_api` being the one this backend uses — are
-/// top-level flags alongside `command`, not values of cgminer's `parameter`
-/// argument. Wrapping them makes the firmware ignore the flag and silently
-/// answer with the legacy payload, which is indistinguishable from a
-/// successful call.
-///
-/// An object is always one of those extensions; cgminer's own convention
-/// passes a scalar (e.g. `switchpool`'s pool index), so scalars keep the
-/// `parameter` wrapper.
+/// `new_api` is a top-level flag alongside `command`, not a value of cgminer's
+/// `parameter` argument. Nested under `parameter` the firmware ignores it and
+/// answers with the legacy payload — a well-formed success a caller cannot
+/// tell apart from the real thing. Everything else keeps the `parameter`
+/// wrapper cgminer expects, e.g. `switchpool`'s pool index.
 fn build_rpc_request(command: &str, parameters: Option<Value>) -> Value {
+    let mut request = json!({ "command": command });
+
     match parameters {
-        Some(Value::Object(params)) => {
-            let mut request = params;
-            // Inserted last so a stray `command` key cannot displace it.
-            request.insert("command".to_string(), Value::from(command));
-            Value::Object(request)
+        Some(Value::Object(mut params)) => {
+            if let Some(new_api) = params.remove(NEW_API_FLAG) {
+                request[NEW_API_FLAG] = new_api;
+            }
+            if !params.is_empty() {
+                request["parameter"] = Value::Object(params);
+            }
         }
-        Some(params) => json!({
-            "command": command,
-            "parameter": params
-        }),
-        None => json!({
-            "command": command
-        }),
+        Some(params) => request["parameter"] = params,
+        None => {}
     }
+
+    request
 }
 
 #[derive(Debug)]
@@ -185,7 +185,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn object_parameters_become_top_level_flags() {
+    fn new_api_becomes_a_top_level_flag() {
         // The firmware only honours `new_api` at the top level; nested under
         // `parameter` it is ignored and the legacy payload comes back.
         assert_eq!(
@@ -204,18 +204,27 @@ mod tests {
     }
 
     #[test]
-    fn absent_parameters_send_the_bare_command() {
+    fn other_object_parameters_keep_the_cgminer_wrapper() {
+        // Only `new_api` is lifted; anything else stays where cgminer wants it.
         assert_eq!(
-            build_rpc_request("version", None),
-            json!({"command": "version"})
+            build_rpc_request("ascset", Some(json!({"idx": 0}))),
+            json!({"command": "ascset", "parameter": {"idx": 0}})
         );
     }
 
     #[test]
-    fn command_wins_over_a_conflicting_parameter_key() {
+    fn new_api_is_lifted_out_of_a_larger_parameter_object() {
         assert_eq!(
-            build_rpc_request("stats", Some(json!({"command": "evil"}))),
-            json!({"command": "stats"})
+            build_rpc_request("stats", Some(json!({"new_api": true, "idx": 0}))),
+            json!({"command": "stats", "new_api": true, "parameter": {"idx": 0}})
+        );
+    }
+
+    #[test]
+    fn absent_parameters_send_the_bare_command() {
+        assert_eq!(
+            build_rpc_request("version", None),
+            json!({"command": "version"})
         );
     }
 }

--- a/asic-rs-firmwares/antminer/src/backends/v2020/rpc.rs
+++ b/asic-rs-firmwares/antminer/src/backends/v2020/rpc.rs
@@ -10,6 +10,35 @@ use asic_rs_core::{
 use async_trait::async_trait;
 use serde_json::{Value, json};
 
+/// Build the JSON request for a cgminer-style RPC call.
+///
+/// Bitmain's API extensions — `new_api` being the one this backend uses — are
+/// top-level flags alongside `command`, not values of cgminer's `parameter`
+/// argument. Wrapping them makes the firmware ignore the flag and silently
+/// answer with the legacy payload, which is indistinguishable from a
+/// successful call.
+///
+/// An object is always one of those extensions; cgminer's own convention
+/// passes a scalar (e.g. `switchpool`'s pool index), so scalars keep the
+/// `parameter` wrapper.
+fn build_rpc_request(command: &str, parameters: Option<Value>) -> Value {
+    match parameters {
+        Some(Value::Object(params)) => {
+            let mut request = params;
+            // Inserted last so a stray `command` key cannot displace it.
+            request.insert("command".to_string(), Value::from(command));
+            Value::Object(request)
+        }
+        Some(params) => json!({
+            "command": command,
+            "parameter": params
+        }),
+        None => json!({
+            "command": command
+        }),
+    }
+}
+
 #[derive(Debug)]
 pub struct AntMinerRPCAPI {
     ip: IpAddr,
@@ -28,16 +57,7 @@ impl AntMinerRPCAPI {
         _privileged: bool,
         parameters: Option<Value>,
     ) -> anyhow::Result<Value> {
-        let request = if let Some(params) = parameters {
-            json!({
-                "command": command,
-                "parameter": params
-            })
-        } else {
-            json!({
-                "command": command
-            })
-        };
+        let request = build_rpc_request(command, parameters);
 
         let json_str = request.to_string();
         let message = format!("{}\n", json_str);
@@ -157,5 +177,45 @@ impl StatusFromAntMiner for RPCCommandStatus {
         }
 
         Ok(Self::Success)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn object_parameters_become_top_level_flags() {
+        // The firmware only honours `new_api` at the top level; nested under
+        // `parameter` it is ignored and the legacy payload comes back.
+        assert_eq!(
+            build_rpc_request("stats", Some(json!({"new_api": true}))),
+            json!({"command": "stats", "new_api": true})
+        );
+    }
+
+    #[test]
+    fn scalar_parameters_keep_the_cgminer_wrapper() {
+        // cgminer's own convention, e.g. `switchpool` with a pool index.
+        assert_eq!(
+            build_rpc_request("switchpool", Some(json!("1"))),
+            json!({"command": "switchpool", "parameter": "1"})
+        );
+    }
+
+    #[test]
+    fn absent_parameters_send_the_bare_command() {
+        assert_eq!(
+            build_rpc_request("version", None),
+            json!({"command": "version"})
+        );
+    }
+
+    #[test]
+    fn command_wins_over_a_conflicting_parameter_key() {
+        assert_eq!(
+            build_rpc_request("stats", Some(json!({"command": "evil"}))),
+            json!({"command": "stats"})
+        );
     }
 }

--- a/asic-rs-firmwares/antminer/src/backends/v2023_07/mod.rs
+++ b/asic-rs-firmwares/antminer/src/backends/v2023_07/mod.rs
@@ -486,11 +486,6 @@ impl GetDataLocations for AntMinerV202307 {
                 },
             )],
             DataField::Wattage => {
-                // Newer stock firmware reports power draw only in the `new_api`
-                // variant of `stats`. That is a different payload to the legacy
-                // one: its `STATS` array holds a single element, so the reading
-                // sits at `/STATS/0` rather than the `/STATS/1` used above.
-                //
                 // Not a `const` because `json!` is not const-evaluable.
                 let rpc_new_stats = MinerCommand::RPC {
                     command: "stats",

--- a/asic-rs-firmwares/antminer/src/backends/v2023_07/mod.rs
+++ b/asic-rs-firmwares/antminer/src/backends/v2023_07/mod.rs
@@ -485,14 +485,37 @@ impl GetDataLocations for AntMinerV202307 {
                     tag: None,
                 },
             )],
-            DataField::Wattage => vec![(
-                RPC_STATS,
-                DataExtractor {
-                    func: get_by_pointer,
-                    key: Some("/STATS/1"),
-                    tag: None,
-                },
-            )],
+            DataField::Wattage => {
+                // Newer stock firmware reports power draw only in the `new_api`
+                // variant of `stats`. That is a different payload to the legacy
+                // one: its `STATS` array holds a single element, so the reading
+                // sits at `/STATS/0` rather than the `/STATS/1` used above.
+                //
+                // Not a `const` because `json!` is not const-evaluable.
+                let rpc_new_stats = MinerCommand::RPC {
+                    command: "stats",
+                    parameters: Some(json!({ "new_api": true })),
+                };
+
+                vec![
+                    (
+                        RPC_STATS,
+                        DataExtractor {
+                            func: get_by_pointer,
+                            key: Some("/STATS/1"),
+                            tag: None,
+                        },
+                    ),
+                    (
+                        rpc_new_stats,
+                        DataExtractor {
+                            func: get_by_pointer,
+                            key: Some("/STATS/0"),
+                            tag: None,
+                        },
+                    ),
+                ]
+            }
             DataField::SerialNumber => vec![
                 (
                     WEB_SYSTEM_INFO,
@@ -812,6 +835,9 @@ impl GetWattage for AntMinerV202307 {
             if let Some(power) = stats_data
                 .get("power")
                 .or_else(|| stats_data.get("Power"))
+                // Same firmware version spells this differently per model: the
+                // L9 reports `power`, the L11 `watt`.
+                .or_else(|| stats_data.get("watt"))
                 .and_then(|v| v.as_f64())
             {
                 return Some(Power::from_watts(power));

--- a/asic-rs-firmwares/antminer/src/backends/v2023_07/rpc.rs
+++ b/asic-rs-firmwares/antminer/src/backends/v2023_07/rpc.rs
@@ -10,33 +10,33 @@ use asic_rs_core::{
 use async_trait::async_trait;
 use serde_json::{Value, json};
 
+/// Bitmain's one API extension to the cgminer protocol.
+const NEW_API_FLAG: &str = "new_api";
+
 /// Build the JSON request for a cgminer-style RPC call.
 ///
-/// Bitmain's API extensions — `new_api` being the one this backend uses — are
-/// top-level flags alongside `command`, not values of cgminer's `parameter`
-/// argument. Wrapping them makes the firmware ignore the flag and silently
-/// answer with the legacy payload, which is indistinguishable from a
-/// successful call.
-///
-/// An object is always one of those extensions; cgminer's own convention
-/// passes a scalar (e.g. `switchpool`'s pool index), so scalars keep the
-/// `parameter` wrapper.
+/// `new_api` is a top-level flag alongside `command`, not a value of cgminer's
+/// `parameter` argument. Nested under `parameter` the firmware ignores it and
+/// answers with the legacy payload — a well-formed success a caller cannot
+/// tell apart from the real thing. Everything else keeps the `parameter`
+/// wrapper cgminer expects, e.g. `switchpool`'s pool index.
 fn build_rpc_request(command: &str, parameters: Option<Value>) -> Value {
+    let mut request = json!({ "command": command });
+
     match parameters {
-        Some(Value::Object(params)) => {
-            let mut request = params;
-            // Inserted last so a stray `command` key cannot displace it.
-            request.insert("command".to_string(), Value::from(command));
-            Value::Object(request)
+        Some(Value::Object(mut params)) => {
+            if let Some(new_api) = params.remove(NEW_API_FLAG) {
+                request[NEW_API_FLAG] = new_api;
+            }
+            if !params.is_empty() {
+                request["parameter"] = Value::Object(params);
+            }
         }
-        Some(params) => json!({
-            "command": command,
-            "parameter": params
-        }),
-        None => json!({
-            "command": command
-        }),
+        Some(params) => request["parameter"] = params,
+        None => {}
     }
+
+    request
 }
 
 #[derive(Debug)]
@@ -185,7 +185,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn object_parameters_become_top_level_flags() {
+    fn new_api_becomes_a_top_level_flag() {
         // The firmware only honours `new_api` at the top level; nested under
         // `parameter` it is ignored and the legacy payload comes back.
         assert_eq!(
@@ -204,18 +204,27 @@ mod tests {
     }
 
     #[test]
-    fn absent_parameters_send_the_bare_command() {
+    fn other_object_parameters_keep_the_cgminer_wrapper() {
+        // Only `new_api` is lifted; anything else stays where cgminer wants it.
         assert_eq!(
-            build_rpc_request("version", None),
-            json!({"command": "version"})
+            build_rpc_request("ascset", Some(json!({"idx": 0}))),
+            json!({"command": "ascset", "parameter": {"idx": 0}})
         );
     }
 
     #[test]
-    fn command_wins_over_a_conflicting_parameter_key() {
+    fn new_api_is_lifted_out_of_a_larger_parameter_object() {
         assert_eq!(
-            build_rpc_request("stats", Some(json!({"command": "evil"}))),
-            json!({"command": "stats"})
+            build_rpc_request("stats", Some(json!({"new_api": true, "idx": 0}))),
+            json!({"command": "stats", "new_api": true, "parameter": {"idx": 0}})
+        );
+    }
+
+    #[test]
+    fn absent_parameters_send_the_bare_command() {
+        assert_eq!(
+            build_rpc_request("version", None),
+            json!({"command": "version"})
         );
     }
 }

--- a/asic-rs-firmwares/antminer/src/backends/v2023_07/rpc.rs
+++ b/asic-rs-firmwares/antminer/src/backends/v2023_07/rpc.rs
@@ -10,6 +10,35 @@ use asic_rs_core::{
 use async_trait::async_trait;
 use serde_json::{Value, json};
 
+/// Build the JSON request for a cgminer-style RPC call.
+///
+/// Bitmain's API extensions — `new_api` being the one this backend uses — are
+/// top-level flags alongside `command`, not values of cgminer's `parameter`
+/// argument. Wrapping them makes the firmware ignore the flag and silently
+/// answer with the legacy payload, which is indistinguishable from a
+/// successful call.
+///
+/// An object is always one of those extensions; cgminer's own convention
+/// passes a scalar (e.g. `switchpool`'s pool index), so scalars keep the
+/// `parameter` wrapper.
+fn build_rpc_request(command: &str, parameters: Option<Value>) -> Value {
+    match parameters {
+        Some(Value::Object(params)) => {
+            let mut request = params;
+            // Inserted last so a stray `command` key cannot displace it.
+            request.insert("command".to_string(), Value::from(command));
+            Value::Object(request)
+        }
+        Some(params) => json!({
+            "command": command,
+            "parameter": params
+        }),
+        None => json!({
+            "command": command
+        }),
+    }
+}
+
 #[derive(Debug)]
 pub struct AntMinerRPCAPI {
     ip: IpAddr,
@@ -28,16 +57,7 @@ impl AntMinerRPCAPI {
         _privileged: bool,
         parameters: Option<Value>,
     ) -> anyhow::Result<Value> {
-        let request = if let Some(params) = parameters {
-            json!({
-                "command": command,
-                "parameter": params
-            })
-        } else {
-            json!({
-                "command": command
-            })
-        };
+        let request = build_rpc_request(command, parameters);
 
         let json_str = request.to_string();
         let message = format!("{}\n", json_str);
@@ -157,5 +177,45 @@ impl StatusFromAntMiner for RPCCommandStatus {
         }
 
         Ok(Self::Success)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn object_parameters_become_top_level_flags() {
+        // The firmware only honours `new_api` at the top level; nested under
+        // `parameter` it is ignored and the legacy payload comes back.
+        assert_eq!(
+            build_rpc_request("stats", Some(json!({"new_api": true}))),
+            json!({"command": "stats", "new_api": true})
+        );
+    }
+
+    #[test]
+    fn scalar_parameters_keep_the_cgminer_wrapper() {
+        // cgminer's own convention, e.g. `switchpool` with a pool index.
+        assert_eq!(
+            build_rpc_request("switchpool", Some(json!("1"))),
+            json!({"command": "switchpool", "parameter": "1"})
+        );
+    }
+
+    #[test]
+    fn absent_parameters_send_the_bare_command() {
+        assert_eq!(
+            build_rpc_request("version", None),
+            json!({"command": "version"})
+        );
+    }
+
+    #[test]
+    fn command_wins_over_a_conflicting_parameter_key() {
+        assert_eq!(
+            build_rpc_request("stats", Some(json!({"command": "evil"}))),
+            json!({"command": "stats"})
+        );
     }
 }


### PR DESCRIPTION
> **Depends on #328.** That PR fixes the RPC transport so `new_api` actually
> reaches the miner. Until it merges, its commit appears here too; afterwards
> this PR is the single `mod.rs` change. Reworked from the web endpoint to RPC
> per review.

`wattage` is always `None` on newer stock firmware. `DataField::Wattage` is
sourced from the legacy RPC `stats` payload, which carries no power reading on
these generations.

## Where the reading lives

The `new_api` variant of `stats` reports it. That is a different payload to the
legacy one — its `STATS` array holds a single element, so the value sits at
`/STATS/0` rather than the `/STATS/1` the legacy source uses:

```
{"command":"stats"}                  -> STATS len 2, Msg "CGMiner stats", no power
{"command":"stats","new_api":true}   -> STATS len 1, Msg "stats",         power/watt present
```

## The change

- Adds `stats` + `new_api` as a second source for `DataField::Wattage`, read at
  `/STATS/0`.
- Accepts the `watt` key alongside the existing `power` / `Power` /
  `chain_power`. The spelling varies by model on identical firmware: the L9
  reports `power`, the L11 `watt`.

The legacy location is kept and tried first, so firmware that does report power
there is unaffected. Applied to both `v2020` and `v2023_07`.

## Measured

Against live hardware, all previously `None`:

```
L11   3651 W        L9   3357 W
L11   3636 W        L9   3353 W
                    L9   3379 W
```

An idle unit reports its true low draw rather than falling back to absent, so a
genuine zero stays distinguishable from a missing reading.

No regressions in the groups that cannot benefit: T21, S21 Hydro and S21+ Hydro
expose no power draw on any transport and continue to report nothing, and older
units that do not honour `new_api` still receive the legacy payload exactly as
before.

The two payloads share only `fan_num` and `rate_30m`, identical in both, so
merging them into one field cannot silently clobber a value.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p asic-rs-firmwares-antminer --all-targets` — clean
- `cargo test -p asic-rs-firmwares-antminer` — 20 passed
- `cargo test --workspace` — no failures
- Live check against multiple L9 and L11 units
