### PR TITLE
fix(epic): implement set_scaling_config instead of reporting false support

### DIFF
--- a/asic-rs-firmwares/epic/src/backends/v1/mod.rs
+++ b/asic-rs-firmwares/epic/src/backends/v1/mod.rs
@@ -1341,7 +1341,17 @@ impl SupportsPoolsConfig for PowerPlayV1 {
     }
 }
 
+#[async_trait]
 impl SupportsScalingConfig for PowerPlayV1 {
+    async fn set_scaling_config(&self, config: ScalingConfig) -> anyhow::Result<bool> {
+        // PowerPlay has no scaling-only endpoint: `min_throttle` and
+        // `throttle_step` are written by the same `perpetualtune/algo` call that
+        // sets the tuning target, so the current target is read and resent to
+        // avoid clobbering it.
+        let current = self.get_tuning_config().await?;
+        self.set_tuning_config(current, Some(config)).await
+    }
+
     fn parse_scaling_config(
         &self,
         data: &HashMap<ConfigField, Value>,
@@ -1984,6 +1994,44 @@ mod tests {
             "miner rejected the perpetual tune settings"
         );
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[ignore = "requires live miner and writes perpetual tune config; set MINER_IP"]
+    async fn set_scaling_config_live_test() -> anyhow::Result<()> {
+        let ip_str = std::env::var("MINER_IP").context("MINER_IP is not set")?;
+        let ip =
+            IpAddr::from_str(&ip_str).with_context(|| format!("invalid MINER_IP: {ip_str}"))?;
+
+        let miner = get_miner(ip, Arc::new(EPicFirmware::default()))
+            .await?
+            .context("no miner detected at MINER_IP")?;
+
+        let original_tuning = miner.get_tuning_config().await?;
+        let original_scaling = miner.get_scaling_config().await?;
+        println!(
+            "original: tuning={} scaling={}",
+            serde_json::to_string_pretty(&original_tuning)?,
+            serde_json::to_string_pretty(&original_scaling)?,
+        );
+
+        let target = ScalingConfig::new(original_scaling.step + 1, original_scaling.minimum);
+        anyhow::ensure!(
+            miner.set_scaling_config(target).await?,
+            "miner rejected the scaling config"
+        );
+
+        // The tuning target must survive a scaling-only write. Compared as JSON
+        // because TuningConfig is not PartialEq.
+        let before = serde_json::to_string(&original_tuning)?;
+        let after = serde_json::to_string(&miner.get_tuning_config().await?)?;
+        anyhow::ensure!(
+            before == after,
+            "scaling write changed the tuning target: {before} -> {after}"
+        );
+
+        miner.set_scaling_config(original_scaling).await?;
         Ok(())
     }
 


### PR DESCRIPTION
## What

`supports_scaling_config()` returns `true` for PowerPlay, but the backend only
ever implemented `parse_scaling_config` — so `set_scaling_config` fell through
to the trait default:

```rust
anyhow::bail!("Setting scaling config is not supported on this platform");
```

PowerPlay is the only backend in the repo whose flag says `true`, and no backend
anywhere implements the setter. A caller that correctly checks the capability
before writing still fails, and fails silently, because the Python binding maps
the error to `None`.

## The fix

Scaling *is* settable on PowerPlay — it just has no endpoint of its own.
`min_throttle` and `throttle_step` are written by the same
`perpetualtune/algo` call that sets the tuning target, which is why #330's live
test passes the current scaling config through `set_tuning_config`.

This is that observation in reverse: read the current tuning config, resend it
with the new scaling. Reading first is the necessary part — without it a
scaling-only write would clobber the tuning target.

```rust
async fn set_scaling_config(&self, config: ScalingConfig) -> anyhow::Result<bool> {
    let current = self.get_tuning_config().await?;
    self.set_tuning_config(current, Some(config)).await
}
```

## Verified

Against a PowerPlay-BMS v1.24.0 unit (Antminer S19j Pro, `BoardTune`, 70 TH/s
target):

```
before:   scaling step=5 min=10   tuning 70 TH/s BoardTune
set_scaling_config(step=7, min=15) -> True
          CHANGED within 5s -> step=7 min=15
          tuning target preserved: 70 TH/s BoardTune
restored: scaling step=5 min=10   tuning 70 TH/s BoardTune
```

The live test added here follows #330's convention and asserts the target
preservation, not just that the write returned `true` — a write that reports
success without changing anything is the failure mode I was chasing in #331.

`cargo clippy` clean; the crate's tests pass (9 passed, 4 ignored live tests).

## One deliberate omission

Asserting the tuning config is unchanged wants `PartialEq` on `TuningConfig`,
which does not exist today. Deriving it would pull `asic-rs-core` into an
epic-only change, so the test compares serialised JSON instead. Happy to add the
derive in a separate PR if you would rather have it.
